### PR TITLE
fix(backend): only allow one file to be attached to a purchase

### DIFF
--- a/apps/backend/prisma/migrations/20220124142547_file_unique_purchase/migration.sql
+++ b/apps/backend/prisma/migrations/20220124142547_file_unique_purchase/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[purchaseId]` on the table `File` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "File_purchaseId_key" ON "File"("purchaseId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -15,7 +15,7 @@ model File {
   createdAt  DateTime  @default(now())
   content    Bytes
   purchase   Purchase? @relation(fields: [purchaseId], references: [id])
-  purchaseId String?
+  purchaseId String?   @unique()
 
   @@index([createdAt])
 }


### PR DESCRIPTION
Only allow one file to be attached to a purchase.