### PR TITLE
feat/popover for eth addresses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ ISSUER_API_PORT=3334
 WEB3=http://localhost:8545
 MNEMONIC=chalk park staff buzz chair purchase wise oak receive avoid avoid home
 ISSUER_CHAIN_ADDRESS=0xD173313A51f8fc37BcF67569b463abd89d81844f
+BLOCK_EXPLORER=https://volta-explorer.energyweb.org
 
 LOG_LEVELS=log,error,warn,debug,verbose
 CORS_ORIGIN=*

--- a/apps/frontend/src/components/EthereumAddress/Popover.tsx
+++ b/apps/frontend/src/components/EthereumAddress/Popover.tsx
@@ -1,0 +1,77 @@
+import ClearIcon from "@mui/icons-material/Clear";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Popover from "@mui/material/Popover";
+import Typography from "@mui/material/Typography";
+import type { FC } from "react";
+import { css } from '@emotion/css';
+import CopyToClipboard from "../CopyToClipboard";
+
+interface EthAddressPopoverProps {
+  address: string;
+  open: boolean;
+  handleOpen: () => void;
+  handleClose: () => void;
+  anchorEl: null;
+}
+
+const EthAddressPopover: FC<EthAddressPopoverProps> = ({ address, anchorEl, open, handleClose, handleOpen }) => {
+  const userExplorerLink = `${window.config.BLOCK_EXPLORER}/address/${address}`;
+  return (
+    <Popover
+      id="eth-address-popover"
+      open={open}
+      anchorEl={anchorEl}
+      className={popoverClass}
+      classes={{ paper: popoverContentClass }}
+      anchorOrigin={{
+        vertical: 'top',
+        horizontal: 'center',
+      }}
+      transformOrigin={{
+        vertical: 'bottom',
+        horizontal: 'center',
+      }}
+      sx={{
+        pointerEvents: 'none',
+      }}
+      onClose={handleClose}
+      PaperProps={{ onMouseEnter: handleOpen, onMouseLeave: handleClose }}
+      disableRestoreFocus
+    >
+      <Box padding="16px" width="470px">
+        <Box display="flex" justifyContent="space-between" alignItems='center' mb="16px">
+          <Typography color="primary" fontSize="18px">
+            Address
+          </Typography>
+          <IconButton onClick={handleClose}>
+            <ClearIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <Box display="flex" justifyContent="space-between" bgcolor="#f7f7f7" padding="10px 8px" >
+          <Typography color="primary">
+            {address}
+          </Typography>
+          <CopyToClipboard value={address} />
+        </Box>
+        <Box display="flex" justifyContent="flex-end" mt="16px">
+          <a style={{ textDecoration: 'none' }} href={userExplorerLink} target="_blank" rel="noreferrer">
+            <Typography color="secondary" fontSize="12px" fontWeight={600}>
+              See on Explorer
+            </Typography>
+          </a>
+        </Box>
+      </Box>
+    </Popover>
+  )
+}
+
+export default EthAddressPopover;
+
+const popoverClass = css`
+  pointer-events: none;
+`;
+
+const popoverContentClass = css`
+  pointer-events: auto;
+`

--- a/apps/frontend/src/components/EthereumAddress/index.tsx
+++ b/apps/frontend/src/components/EthereumAddress/index.tsx
@@ -1,27 +1,63 @@
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
+import { useState, useRef } from 'react';
+import { AddressZero } from '@ethersproject/constants';
 import { ReactComponent as EyeIcon } from '../../assets/svg/eye.svg';
 import CopyToClipboard from '../CopyToClipboard';
+import EthAddressPopover from './Popover';
 
 export interface EthereumAddressProps {
   address: string;
   shortify?: boolean;
   clipboard?: boolean;
   visibility?: boolean;
+  popover?: boolean;
 }
 
 export const EthereumAddress = ({
   address,
   shortify = false,
   clipboard = false,
-  visibility = false
+  visibility = false,
+  popover = false
 }: EthereumAddressProps) => {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const popoverAnchor = useRef(null)
+  const handlePopoverOpen = () => setPopoverOpen(true);
+  const handlePopoverClose = () => setPopoverOpen(false);
+  const addressZero = address === AddressZero;
+  const blockExplorerLink = `${window.config.BLOCK_EXPLORER}/tx/${address}`;
+
   if (address) {
     return (
       <Box title={address}>
-        {shortify ? shortifyEthAddr(address) : address}
-        {clipboard && <CopyToClipboard value={address} />}
-        {visibility && <StyledEyeIcon />}
+        <StyledAddress
+          ref={popoverAnchor}
+          aria-owns={'eth-address-popover'}
+          aria-haspopup="true" popover={popover}
+          onMouseOver={popover ? handlePopoverOpen: undefined}
+          onMouseLeave={popover ? handlePopoverClose: undefined}
+        >
+          {shortify ?  shortifyEthAddr(address) : address}
+        </StyledAddress>
+
+        {clipboard && !addressZero && <CopyToClipboard value={address} />}
+
+        {visibility && !addressZero &&
+          <a href={blockExplorerLink} target="_blank" rel="noreferrer">
+            <StyledEyeIcon />
+          </a>
+        }
+
+        {popover && !addressZero &&
+          <EthAddressPopover
+            open={popoverOpen}
+            address={address}
+            anchorEl={popoverAnchor.current}
+            handleClose={handlePopoverClose}
+            handleOpen={handlePopoverOpen}
+          />
+        }
       </Box>
     );
   } else return <div>NA</div>;
@@ -30,6 +66,10 @@ export const EthereumAddress = ({
 const StyledEyeIcon = styled(EyeIcon)`
   margin-left: 10px;
 `
+
+const StyledAddress = styled('span', { shouldForwardProp: prop => prop !== 'popover' })<{popover: boolean}>(({ popover }) => `
+  cursor: ${popover && 'pointer'};
+`)
 
 export const shortifyEthAddr = (str: string) => {
   return `${str.substr(0, 4)}...${str.substr(str.length - 4, str.length - 1)}`;

--- a/apps/frontend/src/hooks/useAxiosDefaults.ts
+++ b/apps/frontend/src/hooks/useAxiosDefaults.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     config: {
       API_BASE_URL: string;
+      BLOCK_EXPLORER: string;
     };
   }
 }

--- a/apps/frontend/src/index.html.template
+++ b/apps/frontend/src/index.html.template
@@ -18,7 +18,8 @@
     <link rel="icon" type="image/x-icon" href="favicon.png" />
     <script>
       window.config = {
-        API_BASE_URL: '$API_BASE_URL'
+        API_BASE_URL: '$API_BASE_URL',
+        BLOCK_EXPLORER: '$BLOCK_EXPLORER'
       };
     </script>
   </head>

--- a/apps/frontend/src/pages/ProofExamplePage/TableListProofsExample/index.tsx
+++ b/apps/frontend/src/pages/ProofExamplePage/TableListProofsExample/index.tsx
@@ -78,11 +78,11 @@ export const TableListProofsExample: FC = () => {
                         <StyledThCell sx={{ width: '130px' }}>
                           From Address
                         </StyledThCell>
-                        <EthereumAddress shortify address={event.from ?? ''} />
+                        <EthereumAddress popover shortify address={event.from ?? ''} />
                       </StyledTableCell>
                       <StyledTableCell sx={{ display: 'flex', flexDirection: 'column' }}>
                         <StyledThCell>To Address</StyledThCell>
-                        <EthereumAddress shortify address={event.to ?? ''} />
+                        <EthereumAddress popover shortify address={event.to ?? ''} />
                       </StyledTableCell>
                       <StyledTableCell sx={{ marginRight: '22px' }}>
                         <span>

--- a/package.json
+++ b/package.json
@@ -46,11 +46,13 @@
   "dependencies": {
     "@emotion/react": "11.5.0",
     "@emotion/styled": "11.3.0",
+    "@emotion/css": "11.7.1",
     "@energyweb/issuer": "4.1.1-alpha.1637852659.0",
     "@energyweb/issuer-api": "0.4.1-alpha.1637852659.0",
     "@energyweb/origin-backend-utils": "1.6.2-alpha.1637852659.0",
     "@energyweb/utils-general": "11.0.5-alpha.1637852659.0",
     "@ethersproject/bignumber": "5.3.0",
+    "@ethersproject/constants": "5.3.0",
     "@mui/icons-material": "5.2.5",
     "@mui/lab": "5.0.0-alpha.62",
     "@mui/material": "5.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,7 +1195,7 @@
     source-map "^0.5.7"
     stylis "^4.0.3"
 
-"@emotion/babel-plugin@^11.3.0":
+"@emotion/babel-plugin@^11.3.0", "@emotion/babel-plugin@^11.7.1":
   version "11.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
   integrity sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==
@@ -1223,6 +1223,17 @@
     "@emotion/utils" "^1.0.0"
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
+
+"@emotion/css@11.7.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.7.1.tgz#516b717340d36b0bbd2304ba7e1a090e866f8acc"
+  integrity sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==
+  dependencies:
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.3"
+    "@emotion/utils" "^1.0.0"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1254,7 +1265,7 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.0.2":
+"@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
   integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==


### PR DESCRIPTION
1. Added `Popover` for hovering over eth addresses
<img width="584" alt="Screenshot 2022-02-01 at 08 38 04" src="https://user-images.githubusercontent.com/69903849/151923320-d2132c97-ad20-4799-b1ed-8d857c6d238c.png">

2. Added link to block explorer for transaction hashes
<img width="282" alt="Screenshot 2022-02-01 at 08 31 29" src="https://user-images.githubusercontent.com/69903849/151923000-488d0c0f-f1ef-4af3-ab77-0bc8c77b56aa.png">

Currently new features are only added for `proof/example` page. 

**Please note new env variable for UI `BLOCK_EXPLORER`**