### PR TITLE
feat(backend): Multiple API keys support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-API_KEY=somethingsecret
+SUPERADMIN_API_KEY=somethingsecret
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/zero-protocol-labs
 ISSUER_DATABASE_URL=postgresql://postgres:postgres@localhost:5433/issuer
 PG_TRANSACTION_TIMEOUT=120000

--- a/apps/backend/prisma/migrations/20220204152804_api_key/migration.sql
+++ b/apps/backend/prisma/migrations/20220204152804_api_key/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "ApiKeyPermissions" AS ENUM ('CREATE', 'READ', 'UPDATE', 'DELETE', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+    "permissions" "ApiKeyPermissions"[],
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -8,6 +8,21 @@ generator client {
   previewFeatures = ["interactiveTransactions"]
 }
 
+enum ApiKeyPermissions {
+  CREATE
+  READ
+  UPDATE
+  DELETE
+  ADMIN
+}
+
+model ApiKey {
+  id  String @id @default(uuid())
+  name String
+  expires DateTime
+  permissions ApiKeyPermissions[]
+}
+
 model File {
   id        String             @id @default(uuid())
   fileName  String

--- a/apps/backend/src/apikeys/apikeys.module.ts
+++ b/apps/backend/src/apikeys/apikeys.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+
+import { ApiKeysService } from './apikeys.service';
+
+@Global()
+@Module({
+  providers: [ApiKeysService],
+  exports: [ApiKeysService]
+})
+export class ApiKeysModule {}

--- a/apps/backend/src/apikeys/apikeys.service.ts
+++ b/apps/backend/src/apikeys/apikeys.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ApiKey } from '@prisma/client';
+
+@Injectable()
+export class ApiKeysService {
+  constructor(private prisma: PrismaService) {}
+
+  async findAll(): Promise<ApiKey[]> {
+    return this.prisma.apiKey.findMany();
+  }
+
+  async findOne(id: string): Promise<ApiKey> {
+    return this.prisma.apiKey.findUnique({ where: { id } });
+  }
+}

--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { HttpLoggerMiddleware } from '../middlewares/http-logger.middleware';
 import { EmailModule } from '../email/email.module';
 import { HttpsRedirectMiddleware } from '../middlewares/https-redirect.middleware';
 import { ContractsModule } from '../contracts/contracts.module';
+import { ApiKeysModule } from '../apikeys/apikeys.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { ContractsModule } from '../contracts/contracts.module';
     }),
     PrismaModule,
     AuthModule,
+    ApiKeysModule,
     FilesModule,
     PurchasesModule,
     BuyersModule,

--- a/apps/backend/src/auth/header-api-key.strategy.ts
+++ b/apps/backend/src/auth/header-api-key.strategy.ts
@@ -2,11 +2,13 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import Strategy from 'passport-headerapikey';
+import { ApiKeysService } from '../apikeys/apikeys.service';
 
 @Injectable()
 export class HeaderApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
   constructor(
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
+    private readonly apiKeysService: ApiKeysService,
   ) {
     super(
       { header: 'X-API-KEY', prefix: '' },
@@ -16,9 +18,16 @@ export class HeaderApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') 
       });
   }
 
-  public validate = (apiKey: string, done: (error: Error, data) => Record<string, unknown>) => {
-    const keyExpected = this.configService.get<string>('API_KEY');
-    if (keyExpected === apiKey) {
+  public validate = async (apiKey: string, done: (error: Error, data) => Record<string, unknown>) => {
+    const adminKey = this.configService.get<string>('SUPERADMIN_API_KEY');
+
+    if (adminKey === apiKey) {
+      done(null, true);
+    }
+
+    const exists = await this.apiKeysService.findOne(apiKey);
+
+    if (exists) {
       done(null, true);
     }
 

--- a/apps/backend/src/buyers/buyers.controller.ts
+++ b/apps/backend/src/buyers/buyers.controller.ts
@@ -19,47 +19,48 @@ import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs
 import { BuyerDto } from "./dto/buyer.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/buyers')
 @ApiTags('Filecoin buyers')
+@ApiSecurity('api-key', ['api-key'])
+@UseGuards(AuthGuard('api-key'))
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class BuyersController {
   constructor(private readonly buyersService: BuyersService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiCreatedResponse({ type: BuyerDto })
   create(@Body() createBuyerDto: CreateBuyerDto): Promise<BuyerDto> {
     return this.buyersService.create(createBuyerDto);
   }
 
   @Get()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [BuyerDto] })
   findAll(): Promise<BuyerDto[]> {
     return this.buyersService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: BuyerDto })
   findOne(@Param('id') id: string): Promise<BuyerDto> {
     return this.buyersService.findOne(id);
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
   @ApiOkResponse({ type: BuyerDto })
   update(@Param('id') id: string, @Body() updateBuyerDto: UpdateBuyerDto): Promise<BuyerDto> {
     return this.buyersService.update(id, updateBuyerDto);
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
   @ApiOkResponse({ type: Boolean })
   remove(@Param('id') id: string): Promise<boolean> {
     return this.buyersService.remove(id);

--- a/apps/backend/src/certificates/certificates.controller.ts
+++ b/apps/backend/src/certificates/certificates.controller.ts
@@ -19,17 +19,20 @@ import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from
 import { CertificateDto } from "./dto/certificate.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/certificates')
 @ApiTags('Filecoin certificates')
+@UseGuards(AuthGuard('api-key'))
+@ApiSecurity('api-key', ['api-key'])
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class CertificatesController {
   constructor(private readonly certificatesService: CertificatesService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiBody({ type: [CreateCertificateDto] })
   @ApiCreatedResponse({
       type: [CertificateDto],
@@ -40,36 +43,34 @@ export class CertificatesController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [CertificateDto] })
   findAll() {
     return this.certificatesService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: CertificateDto })
   findOne(@Param('id') id: string) {
     return this.certificatesService.findOne(id);
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
-  update(@Param('id') id: string, @Body() updateCertificateDto: UpdateCertificateDto) {
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiOkResponse({ type: CertificateDto })
+  update(@Param('id') id: string, @Body() updateCertificateDto: UpdateCertificateDto): Promise<CertificateDto> {
     return this.certificatesService.update(id, updateCertificateDto);
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
   remove(@Param('id') id: string) {
     return this.certificatesService.remove(id);
   }
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   syncOnChain(@Param('id') id: string) {
     return this.certificatesService.syncOnChain(id);
   }

--- a/apps/backend/src/contracts/contracts.controller.ts
+++ b/apps/backend/src/contracts/contracts.controller.ts
@@ -15,21 +15,24 @@ import {
 import { ContractsService } from './contracts.service';
 import { CreateContractDto } from './dto/create-contract.dto';
 import { UpdateContractDto } from './dto/update-contract.dto';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { ContractDto } from './dto/contract.dto';
 import { NoDataInterceptor } from '../interceptors/NoDataInterceptor';
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/contracts')
 @ApiTags('Filecoin contracts')
+@ApiSecurity('api-key', ['api-key'])
+@UseGuards(AuthGuard('api-key'))
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class ContractsController {
   constructor(private readonly contractsService: ContractsService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiBody({ type: [CreateContractDto] })
   @ApiCreatedResponse({
       type: [ContractDto],
@@ -40,14 +43,14 @@ export class ContractsController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({type: [ContractDto]})
   findAll(): Promise<ContractDto[]> {
     return this.contractsService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: ContractDto })
   @ApiParam({ name: 'id', type: String })
   findOne(@Param('id') id: string): Promise<ContractDto> {
@@ -55,18 +58,18 @@ export class ContractsController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
   @ApiParam({ name: 'id', type: String })
   @ApiBody({ type: UpdateContractDto })
+  @ApiOkResponse({ type: ContractDto })
   update(@Param('id') id: string, @Body() updateContractDto: UpdateContractDto): Promise<ContractDto> {
     return this.contractsService.update(id, updateContractDto);
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
   @ApiParam({ name: 'id', type: Boolean })
+  @ApiOkResponse({ type: Boolean })
   remove(@Param('id') id: string): Promise<boolean> {
     return this.contractsService.remove(id);
   }

--- a/apps/backend/src/contracts/contracts.service.ts
+++ b/apps/backend/src/contracts/contracts.service.ts
@@ -3,7 +3,6 @@ import { CreateContractDto } from './dto/create-contract.dto';
 import { UpdateContractDto } from './dto/update-contract.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { ConfigService } from '@nestjs/config';
-import { CertificatesService } from '../certificates/certificates.service';
 import { BuyersService } from '../buyers/buyers.service';
 import { SellersService } from '../sellers/sellers.service';
 import { FilecoinNodesService } from '../filecoin-nodes/filecoin-nodes.service';
@@ -11,7 +10,7 @@ import { ContractDto } from './dto/contract.dto';
 
 @Injectable()
 export class ContractsService {
-  private readonly logger = new Logger(CertificatesService.name, { timestamp: true });
+  private readonly logger = new Logger(ContractsService.name, { timestamp: true });
 
   constructor(
     private prisma: PrismaService,

--- a/apps/backend/src/filecoin-nodes/filecoin-nodes.controller.ts
+++ b/apps/backend/src/filecoin-nodes/filecoin-nodes.controller.ts
@@ -15,40 +15,48 @@ import {
 import { FilecoinNodesService, transactionsSchema } from './filecoin-nodes.service';
 import { CreateFilecoinNodeDto } from './dto/create-filecoin-node.dto';
 import { UpdateFilecoinNodeDto } from './dto/update-filecoin-node.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { FilecoinNodeDto } from "./dto/filecoin-node.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { FilecoinNodeWithContractsDto } from './dto/filecoin-node-with-contracts.dto';
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/nodes')
 @ApiTags('Filecoin nodes')
+@UseGuards(AuthGuard('api-key'))
+@ApiSecurity('api-key', ['api-key'])
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class FilecoinNodesController {
   constructor(private readonly filecoinNodesService: FilecoinNodesService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiCreatedResponse({ type: FilecoinNodeDto })
   create(@Body() createFilecoinNodeDto: CreateFilecoinNodeDto): Promise<FilecoinNodeDto> {
     return this.filecoinNodesService.create(createFilecoinNodeDto);
   }
 
   @Get()
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [FilecoinNodeDto] })
   findAll(): Promise<FilecoinNodeDto[]> {
     return this.filecoinNodesService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: FilecoinNodeDto })
   findOne(@Param('id') id: string): Promise<FilecoinNodeDto> {
     return this.filecoinNodesService.findOne(id);
   }
 
   @Get(':id/contracts')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: FilecoinNodeWithContractsDto })
   findOneWithContracts(@Param('id') id: string): Promise<FilecoinNodeWithContractsDto> {
     return this.filecoinNodesService.findOneWithContracts(id);
@@ -56,21 +64,23 @@ export class FilecoinNodesController {
 
   @Patch(':id')
   @ApiOkResponse({ type: FilecoinNodeDto })
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @ApiParam({ name: 'id', type: String })
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
   update(@Param('id') id: string, @Body() updateFilecoinNodeDto: UpdateFilecoinNodeDto): Promise<FilecoinNodeDto> {
     return this.filecoinNodesService.update(id, updateFilecoinNodeDto);
   }
 
   @Delete(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: Boolean })
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
   remove(@Param('id') id: string): Promise<boolean> {
     return this.filecoinNodesService.remove(id);
   }
 
   @Get(':id/transactions')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ schema: transactionsSchema })
   getTransactions(@Param('id') id: string) {
     return this.filecoinNodesService.getTransactions(id);

--- a/apps/backend/src/guards/apikey-permissions.guard.ts
+++ b/apps/backend/src/guards/apikey-permissions.guard.ts
@@ -1,0 +1,45 @@
+import { ConfigService } from '@nestjs/config';
+import { CanActivate, ExecutionContext, Injectable, mixin } from '@nestjs/common';
+import { Request } from 'express';
+import { ApiKeyPermissions } from '@prisma/client';
+import { ApiKeysService } from '../apikeys/apikeys.service';
+import { Type } from '@nestjs/passport';
+import { memoize } from '../utils/memoize';
+
+export const ApiKeyPermissionsGuard: (
+  neededPermissions: ApiKeyPermissions[]
+) => Type<CanActivate> = memoize(createApiKeyPermissionsGuard);
+
+function createApiKeyPermissionsGuard(neededPermissions: ApiKeyPermissions[]): Type<CanActivate> {
+  @Injectable()
+  class MixinApiKeyPermissionsGuard implements CanActivate {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly apiKeysService: ApiKeysService
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const request: Request = context.switchToHttp().getRequest();
+      const apiKey = request.headers['x-api-key'] as string;
+      
+      const adminKey = this.configService.get<string>('SUPERADMIN_API_KEY');
+
+      if (adminKey === apiKey) {
+        return true;
+      }
+
+      const apiKeyEntity = await this.apiKeysService.findOne(apiKey);
+
+      if (apiKeyEntity) {
+          return neededPermissions.every(
+              perm => apiKeyEntity.permissions.includes(perm)
+          );
+      }
+
+      return false;
+    }
+  };
+  
+  const guard = mixin(MixinApiKeyPermissionsGuard);
+  return guard;
+}

--- a/apps/backend/src/issuer/issuer.service.ts
+++ b/apps/backend/src/issuer/issuer.service.ts
@@ -43,7 +43,7 @@ export class IssuerService {
   ) {
     this.axiosInstance = axios.create({
       baseURL: `${configService.get('ISSUER_API_BASE_URL')}/api`,
-      headers: { 'X-Api-Key': configService.get('API_KEY') }
+      headers: { 'X-Api-Key': configService.get('SUPERADMIN_API_KEY') }
     });
   }
 

--- a/apps/backend/src/orders/orders.controller.ts
+++ b/apps/backend/src/orders/orders.controller.ts
@@ -9,31 +9,40 @@ import {
   Patch,
   Post,
   Put,
+  UseGuards,
   UseInterceptors,
   UsePipes,
   ValidationPipe
 } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { OrderDto } from "./dto/order.dto";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ConfirmOrderDto } from './dto/confirm-order.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('orders')
 @ApiTags('Orders')
+@UseGuards(AuthGuard('api-key'))
+@ApiSecurity('api-key', ['api-key'])
 @UsePipes(new ValidationPipe({whitelist: true}))
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiCreatedResponse({ type: OrderDto })
   create(@Body() createOrderDto: CreateOrderDto): Promise<OrderDto> {
     return this.ordersService.create(createOrderDto);
   }
 
   @Put(':id/confirmations')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: OrderDto })
   confirm(
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
@@ -43,23 +52,30 @@ export class OrdersController {
   }
 
   @Get()
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [OrderDto] })
   findAll(): Promise<OrderDto[]> {
     return this.ordersService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: OrderDto })
   findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     return this.ordersService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiParam({ name: 'id', type: String })
   update(@Param('id') id: string) {
     return this.ordersService.update(+id);
   }
 
   @Delete(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
+  @ApiParam({ name: 'id', type: String })
   remove(@Param('id') id: string) {
     return this.ordersService.remove(+id);
   }

--- a/apps/backend/src/purchases/purchases.controller.ts
+++ b/apps/backend/src/purchases/purchases.controller.ts
@@ -23,17 +23,20 @@ import { FileMetadataDto } from '../files/dto/file-metadata.dto';
 import { FullPurchaseDto } from './dto/full-purchase.dto';
 import { ShortPurchaseDto } from './dto/short-purchase.dto';
 import { GenerateAttestationsDto } from './dto/generate-attestations.dto';
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/purchases')
 @ApiTags('Filecoin purchases')
+@UseGuards(AuthGuard('api-key'))
+@ApiSecurity('api-key', ['api-key'])
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class PurchasesController {
   constructor(private readonly purchasesService: PurchasesService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiBody({ type: [CreatePurchaseDto] })
   @ApiCreatedResponse({
       type: [FullPurchaseDto],
@@ -44,15 +47,14 @@ export class PurchasesController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
-  @ApiOkResponse({ type: ShortPurchaseDto })
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [ShortPurchaseDto] })
   findAll(): Promise<ShortPurchaseDto[]> {
     return this.purchasesService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: FullPurchaseDto })
   findOne(@Param('id') id: string): Promise<FullPurchaseDto> {
@@ -60,16 +62,14 @@ export class PurchasesController {
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
   @ApiParam({ name: 'id', type: String })
   update(@Param('id') id: string, @Body() updatePurchaseDto: UpdatePurchaseDto) {
     return this.purchasesService.update(id, updatePurchaseDto);
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
   @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: Boolean })
   remove(@Param('id') id: string): Promise<boolean> {
@@ -77,6 +77,7 @@ export class PurchasesController {
   }
 
   @Get(':id/blockchain-events')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ schema: purchaseEventsSchema })
   @ApiParam({ name: 'id', type: String })
   async getBlockchainEvents(@Param('id') id: string) {
@@ -84,8 +85,7 @@ export class PurchasesController {
   }
 
   @Post('/generate/attestations')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
   @ApiBody({ type: GenerateAttestationsDto })
   @ApiCreatedResponse({ type: [FileMetadataDto] })
   generateAttestations(@Body() { purchaseIds, }: GenerateAttestationsDto): Promise<FileMetadataDto[]> {

--- a/apps/backend/src/sellers/sellers.controller.ts
+++ b/apps/backend/src/sellers/sellers.controller.ts
@@ -15,49 +15,55 @@ import {
 import { SellersService } from './sellers.service';
 import { CreateSellerDto } from './dto/create-seller.dto';
 import { UpdateSellerDto } from './dto/update-seller.dto';
-import { ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { SellerDto } from "./dto/seller.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
+import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { ApiKeyPermissions } from '@prisma/client';
 
 @Controller('/partners/filecoin/sellers')
 @ApiTags('Filecoin sellers')
+@UseGuards(AuthGuard('api-key'))
+@ApiSecurity('api-key', ['api-key'])
 @UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class SellersController {
   constructor(private readonly sellersService: SellersService) {}
 
   @Post()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.CREATE]))
+  @ApiBody({ type: CreateSellerDto })
+  @ApiCreatedResponse({ type: SellerDto })
   create(@Body() createSellerDto: CreateSellerDto): Promise<SellerDto> {
     return this.sellersService.create(createSellerDto);
   }
 
   @Get()
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
   @ApiOkResponse({ type: [SellerDto] })
   findAll(): Promise<SellerDto[]> {
     return this.sellersService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: SellerDto })
   findOne(@Param('id') id: string): Promise<SellerDto> {
     return this.sellersService.findOne(id);
   }
 
   @Patch(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiParam({ name: 'id', type: String })
   update(@Param('id') id: string, @Body() updateSellerDto: UpdateSellerDto): Promise<SellerDto> {
     return this.sellersService.update(id, updateSellerDto);
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('api-key'))
-  @ApiSecurity('api-key', ['api-key'])
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
+  @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: Boolean })
   remove(@Param('id') id: string): Promise<boolean> {
     return this.sellersService.remove(id);

--- a/apps/backend/src/utils/memoize.ts
+++ b/apps/backend/src/utils/memoize.ts
@@ -1,0 +1,15 @@
+const defaultKey = 'default';
+
+export function memoize(fn: any) {
+  const cache = {};
+  return (...args) => {
+    const n = args[0] || defaultKey;
+    if (n in cache) {
+      return cache[n];
+    } else {
+      const result = fn(n === defaultKey ? undefined : n);
+      cache[n] = result;
+      return result;
+    }
+  };
+}

--- a/apps/issuer-api/src/app/app.module.ts
+++ b/apps/issuer-api/src/app/app.module.ts
@@ -50,7 +50,7 @@ const OriginAppTypeOrmModule = () => {
         NODE_ENV: Joi.string()
           .valid('development', 'production', 'test')
           .default('development'),
-        API_KEY: Joi.string().required(),
+        SUPERADMIN_API_KEY: Joi.string().required(),
         PORT: Joi.number().default(3334),
         LOG_LEVELS: Joi.string().default('log,error,warn,debug,verbose'),
         WEB3: Joi.string().default('http://localhost:8545'),

--- a/apps/issuer-api/src/auth/issuer.guard.ts
+++ b/apps/issuer-api/src/auth/issuer.guard.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
 @Injectable()
@@ -9,6 +9,6 @@ export class IssuerGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request: Request = context.switchToHttp().getRequest();
 
-    return request.headers['x-api-key'] === this.configService.get<string>('API_KEY');
+    return request.headers['x-api-key'] === this.configService.get<string>('SUPERADMIN_API_KEY');
   }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     environment:
       LOG_LEVELS: "log,error,warn,debug,verbose"
       DATABASE_URL: "postgresql://postgres:postgres@db:5432/zero-protocol-labs"
-      API_KEY: somethingsecret
+      SUPERADMIN_API_KEY: somethingsecret
       CORS_ORIGIN: "*"
       CORS_MAX_AGE: 900
       UPLOADED_FILE_SIZE_LIMIT: 200000
@@ -51,7 +51,7 @@ services:
     environment:
       PORT: 3333
       LOG_LEVELS: "log,error,warn,debug,verbose"
-      API_KEY: somethingsecret
+      SUPERADMIN_API_KEY: somethingsecret
       DATABASE_URL: "postgresql://postgres:postgres@db-issuer:5432/issuer"
       WEB3: http://ganache:8545
       MNEMONIC: "chalk park staff buzz chair purchase wise oak receive avoid avoid home"

--- a/seed-dev.sh
+++ b/seed-dev.sh
@@ -1,4 +1,4 @@
-X_API_KEY=$(grep API_KEY .env | cut -d "=" -f2 | tr -d '"');
+X_API_KEY=$(grep SUPERADMIN_API_KEY .env | cut -d "=" -f2 | tr -d '"');
 PORT=$(grep -e "^PORT=" .env | cut -d "=" -f2 | tr -d '"');
 
 echo


### PR DESCRIPTION
We should allow different API keys to be used in the backend.

Each API key should have some kind of permission level.

Initial permissions:
1. **Create**
2. **Read**
3. **Update**
4. **Delete**

We can keep the current **API_KEY** entry as the **Super Admin API key** (i.e. all permissions).

---

_Note: For security reasons, there are no API endpoints for generating API keys. They can only be created by **adding a manual entry to the database**._

_Example SQL command for adding an API key to db:_
```sql
INSERT INTO "ApiKey"(id,name,expires,permissions) VALUES ('367779fe-dcf9-4087-a748-ab016a686218', 'Josephs API key', '2022-06-02T00:00:00.000', '{READ,CREATE}');
```