### PR TITLE
chore(backend): Store the file type in the relation to purchase

### DIFF
--- a/apps/backend/prisma/migrations/20220408140844_file_type_to_relation/migration.sql
+++ b/apps/backend/prisma/migrations/20220408140844_file_type_to_relation/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "FilesOnPurchases" DROP CONSTRAINT "FilesOnPurchases_pkey";
+ALTER TABLE "FilesOnPurchases" ADD COLUMN "fileType" "FileType";
+UPDATE "FilesOnPurchases" AS fp SET "fileType" = f."fileType" FROM "File" AS f WHERE fp."fileId" = f.id;
+
+ALTER TABLE "FilesOnPurchases" ALTER COLUMN "fileType" SET NOT NULL;
+ALTER TABLE "FilesOnPurchases" ADD CONSTRAINT "FilesOnPurchases_pkey" PRIMARY KEY ("fileId", "purchaseId", "fileType");
+
+ALTER TABLE "File" DROP COLUMN "fileType";

--- a/apps/backend/prisma/migrations/20220408143215_file_type_unique_in_purchase/migration.sql
+++ b/apps/backend/prisma/migrations/20220408143215_file_type_unique_in_purchase/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[purchaseId,fileType]` on the table `FilesOnPurchases` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "FilesOnPurchases_purchaseId_fileType_key" ON "FilesOnPurchases"("purchaseId", "fileType");

--- a/apps/backend/prisma/remove_duplicates.sql
+++ b/apps/backend/prisma/remove_duplicates.sql
@@ -1,0 +1,171 @@
+/* UPDATE ALL DUPLICATES TO USE THE SAME FILE */
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_Canada (1).pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '1c076a8c-19de-4469-8559-2996c2e54d6f';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '998ebd95-d680-482a-8fd2-5d7d457bfdd8';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'e947776e-42ba-4ad7-bf77-579d8e4a71a9';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '01d8fcc2-9d48-4594-a1b7-020225d7a765';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '2a17a816-76b3-43a0-a8d1-adbba7359a47';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'd24ab9b2-6161-4bdd-bad2-0a2f59c1ca5c';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '55f8a2df-27d0-46ff-8e52-21d528a4ab49';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '113bcc93-82dc-456d-966f-9509920ea66d';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'b750d3f9-94d5-48cf-8df6-f281cc6c3dcb';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '4ea895b2-fd43-4291-b39e-59f8b6654259';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '98e0d627-1fe3-49dd-83e9-d58acf07d5e9';
+UPDATE "FilesOnPurchases" SET "fileId" = '0217f730-13f7-42fd-9b3a-ab69a91e0bb9' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '8222513e-ec94-4dc5-9309-642f5eef1c2f';
+
+/* Delete duplicates of Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_Canada (1).pdf */
+DELETE FROM "File" WHERE id = '50d136c4-470a-4e75-abde-226658fc0878';
+DELETE FROM "File" WHERE id = 'df8fabd2-6968-4959-bfe1-293f225ee0c2';
+DELETE FROM "File" WHERE id = '7653ee56-841a-439a-b735-18983c1a424a';
+DELETE FROM "File" WHERE id = '7c356c8f-bfbf-4ea1-84ab-dd22b620eb63';
+DELETE FROM "File" WHERE id = '6f97b83d-d716-40da-b127-11b77ff48188';
+DELETE FROM "File" WHERE id = '8928282d-1312-4f3c-bd9a-889a9021b15a';
+DELETE FROM "File" WHERE id = '7a841e90-b4c0-4903-aee4-297c3fcf7844';
+DELETE FROM "File" WHERE id = '85da9038-810d-4c08-b8ba-ce0cce424c2f';
+DELETE FROM "File" WHERE id = '00226ff7-2d6a-4692-a208-ac59c856b321';
+DELETE FROM "File" WHERE id = 'be66e711-b552-49dd-b24d-cbee7a35b017';
+DELETE FROM "File" WHERE id = '6a473e39-864d-4aab-a884-b22c53d7f68f';
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_Michigan (1).pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '1a870fd8-1849-4be3-818a-7149a42f141e';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'bebb97b7-ca17-4d81-83be-26df65c0d82c';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '616b1220-c570-4beb-91f9-7a311c2c1fef';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '8aa42636-7d68-4505-be74-8a5ed9206bdc';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'bbedb387-c601-48d9-81ea-f4f4f25116cc';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'd52af647-7324-48ad-9fc5-14444bbcaa0b';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '556ed87e-8ae8-48f9-921e-c633db0b4ec2';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'af2d97ff-9ecb-4c02-a405-e6e801ce547b';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'c7abfc7f-a7c0-4d45-9972-d67f94c82c74';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'ffb0a982-692f-426d-8223-6600f20e4cc6';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'aa58d2f2-86a0-4edb-96bb-9e37b418a4c8';
+UPDATE "FilesOnPurchases" SET "fileId" = '8356dff5-cc35-48ab-84e4-32b1bde78a91' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '602395a0-07e9-4a0c-a677-77115d67d1d4';
+
+/* Delete duplicates of Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_Michigan (1).pdf */
+DELETE FROM "File" WHERE id = 'b8650a47-24e9-4246-bde1-61286290b950';
+DELETE FROM "File" WHERE id = 'c0ad3357-48a7-470f-8c42-aea85d1442fb';
+DELETE FROM "File" WHERE id = '2ba71922-1d1d-4350-9d5f-a642ae370b50';
+DELETE FROM "File" WHERE id = 'b03acc71-ba9c-4cf3-98bb-ac5f9ba5856d';
+DELETE FROM "File" WHERE id = '10de3a80-70d4-499c-9a4b-38f3fbb70dd9';
+DELETE FROM "File" WHERE id = '6e2fcfc4-19f0-4d92-ab4b-c190352cdcb2';
+DELETE FROM "File" WHERE id = 'f04b05f9-f227-4c15-81d6-ba6126b5761d';
+DELETE FROM "File" WHERE id = '5c5901d5-54f0-4190-b9a3-70f07bcf46fc';
+DELETE FROM "File" WHERE id = 'b4e4ceb5-36a5-4d5b-ab66-dfd6347dc9ed';
+DELETE FROM "File" WHERE id = '3f8b8dd6-29fb-45fb-9033-2a1c20682690';
+DELETE FROM "File" WHERE id = '8b2ca73e-2117-4a36-876d-cee00364276a';
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE Green-e_Attestation.pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'eddf1175-f2a0-4c27-ac18-2a52306c0bf8';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '5253751e-9072-4c05-a3ae-e42428baa429';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '9c7dce70-a91b-4227-8163-e4c985904597';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '82cd99fc-087b-4dbf-9d1e-1c6aac9e269b';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '29ee1544-3805-4b31-8bf2-481970f7137e';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'aa46e90a-6297-42c3-9bf8-41a8619f02ad';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '3e0d54e7-8f38-4af4-842a-03ec60d51b27';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '655a98c4-4062-4931-b7c2-abf7ee23a593';
+UPDATE "FilesOnPurchases" SET "fileId" = 'b2c523d7-f352-4ce2-827a-819197bbf04c' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '0c5114eb-1800-4430-a561-f9bd2dd8289b';
+
+/* Delete duplicates of Green-e_Attestation.pdf */
+DELETE FROM "File" WHERE id = '648c16b3-6a33-48d5-a222-ba1906ec81a5';
+DELETE FROM "File" WHERE id = 'e37bee2b-4a3b-4d9c-aca5-f3e6dcd6dfe1';
+DELETE FROM "File" WHERE id = '3ecf0c6e-295a-4679-92ac-4658c6a7a7a0';
+DELETE FROM "File" WHERE id = 'e806c812-a021-4f71-9137-dacc4ce5fe6b';
+DELETE FROM "File" WHERE id = '15950d93-5267-4ca7-982f-a4837b253d71';
+DELETE FROM "File" WHERE id = '5abaab90-18f3-432d-8e14-2661b315237c';
+DELETE FROM "File" WHERE id = 'fb7d7d77-588e-4b73-a305-06940d4b0b75';
+DELETE FROM "File" WHERE id = '7e6cf07a-98a9-4141-93f9-a1d39a1ff825';
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_NewYork (1).pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '7d9c07a2-31c9-4e65-91df-41c9840a24cc';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '1044fa65-cfbb-4bc0-bd5b-bb81bacaed6f';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'fd3de35e-d548-4137-bfed-38e27bf858d4';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'd4e42744-eca3-44e8-a439-9a0be3664af9';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '5cf094d5-9655-4397-be40-1ddb37331d4b';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '95d0d6d7-777e-4053-88e0-9588e6f41eb9';
+UPDATE "FilesOnPurchases" SET "fileId" = 'ac17957d-0858-4893-b0dd-04852ce665c2' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'ec29d4d2-e99f-41f9-81c9-91f512746bee';
+
+/* Delete duplicates of Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_NewYork (1).pdf */
+DELETE FROM "File" WHERE id = 'c6dbb1c3-d75b-48eb-8672-fb2ba985d132';
+DELETE FROM "File" WHERE id = '1a5068d8-fad6-4bc9-b355-98f56bf94772';
+DELETE FROM "File" WHERE id = '05ccd510-17db-4a54-949f-2c0ae1a5eea6';
+DELETE FROM "File" WHERE id = '5cae9b9f-b6f6-467b-b1d0-1aab19c22fda';
+DELETE FROM "File" WHERE id = 'c4012685-ca67-4b90-b2db-dc669d0929a5';
+DELETE FROM "File" WHERE id = '1cd7365e-0b40-434e-82e3-3ad92c893c7c';
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_California (1).pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '59d99709-f1b5-4bbd-8a77-9867dd26838f';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '4be4660c-7384-4eeb-89e0-3d54ffd2f75f';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '012a6c1a-d9ab-42a8-8ded-afcf3a0bc94e';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'ad4d3d2d-e53b-42fe-8884-1b7f617e1c85';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '0acaca63-9fb6-48b9-a987-0b4b601fc5b3';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '217a1c9b-d684-4bfa-8a67-e6ff446c961c';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '7300fd0c-5c07-4800-a065-21873c1da7d4';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'aa071e56-c5e0-41a6-ae7d-cfeea5cfaf33';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '93672d98-8143-41c7-b2b9-574a803ec182';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'd801f647-f155-4e7d-9f47-a01a1d700761';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '04e1bc3b-3558-4301-90e1-ae28f0f61c23';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '136c4d62-90b2-4167-b58f-9ad212e1a5c1';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '61c7cf9d-354f-40f8-b7ea-b2e4aebbb0b0';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '6ce1111c-b583-46e3-8018-ee5f2525e589';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '7a6f8b1b-5c0c-47c8-8390-b531ab3b8c44';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '38162fae-75c7-4d44-a9de-29facc0464ac';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '615dfa11-c71d-4cc5-b08c-7f49e06f5a44';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'dafb5889-e7fe-4ed8-9d58-2c7c2695f996';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '4f9ca597-e123-49e7-913a-fc15c669f7d9';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '40bef465-8a6d-46aa-ae99-44289bbda440';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '51916ed2-9bda-4170-87af-4174dc4ce55d';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'd88c7288-3dff-4c72-b8e1-79b472d65720';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '5009e630-04f7-4df5-bfbb-2d81b6aaa2a5';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '918f0d0a-c863-45d9-a856-866805a5f3df';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '07db8377-84a0-4f31-8a7d-87f739354f20';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '33f05e89-d5e2-4cae-8092-57866ab45a87';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = 'a9763d23-7a95-4332-ae69-bec0d2ff1350';
+UPDATE "FilesOnPurchases" SET "fileId" = '7efbf2af-d49f-459e-af89-d575f6a43b12' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '68453681-e1ec-4e2e-b8a7-33b3021528ff';
+
+/* Delete duplicates of Green-e_Attestation_Protocol Labs_8996_RY2021_20290_120221_California (1).pdf */
+DELETE FROM "File" WHERE id = 'f2d81cfc-5b30-421f-8106-0d0a426d1473';
+DELETE FROM "File" WHERE id = '6fe78a24-02a1-4b53-91c9-e889a44ae19d';
+DELETE FROM "File" WHERE id = '81b0a143-cd2a-412d-a973-1248e092ad5a';
+DELETE FROM "File" WHERE id = '4ae2a566-cd43-4b34-9147-07d350b0c3c8';
+DELETE FROM "File" WHERE id = 'c950c010-6cb2-49d6-8e1a-27182a69a4a1';
+DELETE FROM "File" WHERE id = '5ed39137-1bbb-4328-ac22-5347292ea35f';
+DELETE FROM "File" WHERE id = '12205c59-68dd-46c9-8af3-e62f65f67cdb';
+DELETE FROM "File" WHERE id = 'db28f730-350c-4d20-a96f-d4d4a079fcca';
+DELETE FROM "File" WHERE id = '9c1c77be-199c-4610-9f0f-c1e34993ced9';
+DELETE FROM "File" WHERE id = 'a75b379d-7679-4a94-a2c7-94e7a20381c0';
+DELETE FROM "File" WHERE id = '1dd99a09-40ba-4838-b117-05362822b995';
+DELETE FROM "File" WHERE id = '9a1e60c1-5a46-4a83-b528-870881502b33';
+DELETE FROM "File" WHERE id = '6f8b9b66-7653-4569-9292-aa57dea2cf33';
+DELETE FROM "File" WHERE id = 'dcb2cb96-e744-4768-8430-ac4b7b354daf';
+DELETE FROM "File" WHERE id = '9cd7af55-70e5-427a-b201-4dee86d3c0f5';
+DELETE FROM "File" WHERE id = '1206ff2f-f69b-4ca0-8e69-c99e31f968c4';
+DELETE FROM "File" WHERE id = '324f9da2-eed7-4ea0-a027-468621b26560';
+DELETE FROM "File" WHERE id = '4860410d-773e-4d9c-9179-1632e21ba3d7';
+DELETE FROM "File" WHERE id = 'a51f404a-7802-41ea-bbe4-560e370c2ed9';
+DELETE FROM "File" WHERE id = '87c17dc8-8392-474f-a269-8fabf6035425';
+DELETE FROM "File" WHERE id = '66e3c292-2ee4-4c74-aa00-5aadca7ed6cc';
+DELETE FROM "File" WHERE id = 'ab0e49ba-95a9-4224-ab17-25bea66a58f9';
+DELETE FROM "File" WHERE id = '794015ff-4673-485e-8a44-a25b0a0ed40e';
+DELETE FROM "File" WHERE id = '3655de12-3fed-4bbf-ae0c-777fbddc3ee9';
+DELETE FROM "File" WHERE id = '79eeb88a-c848-418f-842d-f73127c10b85';
+DELETE FROM "File" WHERE id = '030014aa-6f07-4b53-bfd2-6300a22a3601';
+DELETE FROM "File" WHERE id = '531b829a-40f3-4885-ae6b-93239cf671fa';
+
+/* -------------------------------------------------------------------------------- */
+
+/* FILE GO_Cancellation_MinerID0f1234_2020-2021_Belgium_98.pdf */
+UPDATE "FilesOnPurchases" SET "fileId" = '965d7457-e69d-4237-97dd-b5a7b3e3c833' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '692e9f04-bce5-419a-ac3b-f2c22e5712b9';
+UPDATE "FilesOnPurchases" SET "fileId" = '965d7457-e69d-4237-97dd-b5a7b3e3c833' WHERE "fileType" = 'REDEMPTION_STATEMENT' AND "purchaseId" = '202e33e8-4491-4b7e-9771-9c3882e0154c';
+
+/* Delete duplicates of GO_Cancellation_MinerID0f1234_2020-2021_Belgium_98.pdf */
+DELETE FROM "File" WHERE id = 'b8b0d25f-b61a-43e2-ac7f-a52c402b0a73';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -32,7 +32,6 @@ model File {
   fileName  String
   mimeType  String
   content   Bytes
-  fileType  FileType           @default(ATTESTATION)
   purchases FilesOnPurchases[]
 
   createdAt DateTime @default(now())
@@ -154,11 +153,13 @@ model FilesOnPurchases {
   fileId     String
   purchase   Purchase @relation(fields: [purchaseId], references: [id])
   purchaseId String // relation scalar field (used in the `@relation` attribute above)
+  fileType  FileType
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  @@id([fileId, purchaseId])
+  @@id([fileId, purchaseId, fileType])
+  @@unique([purchaseId, fileType])
 }
 
 model Order {

--- a/apps/backend/src/files/dto/file-metadata.dto.ts
+++ b/apps/backend/src/files/dto/file-metadata.dto.ts
@@ -44,6 +44,7 @@ export class FileMetadataDto implements File {
     return {
       ...dbEntity,
       purchases: dbEntity.purchases.map(p => p.purchaseId),
+      fileType: dbEntity.purchases.pop()?.fileType ?? undefined,
       content: dbEntity.content ?? undefined
     };
   }

--- a/apps/backend/src/files/files.service.ts
+++ b/apps/backend/src/files/files.service.ts
@@ -17,14 +17,14 @@ export class FilesService {
         content: buffer,
         fileName: filename,
         mimeType: mimeType,
-        fileType,
         purchases: {
           create: purchaseIds.map((id) => ({
             purchase: {
               connect: {
-                id
+                id,
               },
-            }
+            },
+            fileType
           }))
         }
       },
@@ -48,7 +48,6 @@ export class FilesService {
         createdAt: true,
         updatedAt: true,
         purchases: true,
-        fileType: true
       }
     });
 

--- a/apps/backend/src/purchases/purchases.service.ts
+++ b/apps/backend/src/purchases/purchases.service.ts
@@ -185,11 +185,12 @@ export class PurchasesService {
         files: {
           select: {
             file: {
-              select: {
-                id: true,
-                fileName: true,
-                mimeType: true,
-                fileType: true
+              include: {
+                purchases: {
+                  select: {
+                    fileType: true
+                  }
+                }
               }
             }
           }
@@ -201,7 +202,20 @@ export class PurchasesService {
       return null;
     }
 
-    return FullPurchaseDto.toDto({ ...data, filecoinNodes: data.filecoinNodes.map((r) => r.filecoinNode) });
+    return FullPurchaseDto.toDto({
+      ...data,
+      filecoinNodes: data.filecoinNodes.map((r) => r.filecoinNode),
+      files: data.files.map(f => {
+        const { purchases, ...file } = f.file;
+
+        return {
+          file: {
+            ...file,
+            fileType: purchases.pop()?.fileType
+          }
+        };
+      }) 
+    });
   }
 
   async update(id: string, updatePurchaseDto: UpdatePurchaseDto) {


### PR DESCRIPTION
Store the `fileType` in the relation to the purchase, not the file itself.