### PR TITLE
feat: add redemption statement to proof-sankey

### DIFF
--- a/apps/backend/src/files/files.controller.ts
+++ b/apps/backend/src/files/files.controller.ts
@@ -97,7 +97,7 @@ export class FilesController {
   }
 
   @Get(':id/metadata')
-  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.PUBLIC, ApiKeyPermissions.READ]))
   @ApiParam({ name: 'id', type: String })
   @ApiOkResponse({ type: FileMetadataDto })
   @UseInterceptors(NoDataInterceptor)

--- a/apps/frontend/src/components/BeneficiaryPage/CertificatesWithFilters.tsx
+++ b/apps/frontend/src/components/BeneficiaryPage/CertificatesWithFilters.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "react-router";
 import { css } from "@emotion/css";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import MenuItem from "@mui/material/MenuItem";
 import { SelectChangeEvent } from "@mui/material/Select";
 import { styled, useTheme } from "@mui/material/styles";
@@ -16,6 +15,7 @@ import { ReactComponent as ListSVG } from '../../assets/svg/list.svg';
 import EthereumAddress from "../EthereumAddress";
 import { Unit, formatPower, ProductEnumType, getContractTotalVolume } from "../../utils";
 import FuelType, { FuelTypeEnum } from "../FuelType";
+import SecondaryButton from "../SecondaryButton";
 import ButtonRight from "./ButtonRight";
 import SankeyView from "./SankeyView";
 
@@ -265,28 +265,6 @@ const StyledMenuItem = styled(MenuItem)(({ theme }) => `
     color: ${theme.palette.primary.main};
   };
 `);
-
-const SecondaryButton = styled(Button, { shouldForwardProp: (prop) => prop !== 'active' })<{ active?: boolean }>(({ theme, active }) => `
-  background-color: ${active ? theme.palette.secondary.main : theme.palette.background.paper};
-  color: ${active ? theme.palette.text.primary : theme.palette.primary.main};
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0px 4px 10px rgba(160, 154, 198, 0.2);
-  border-radius: 5px;
-  padding: 10px 12px;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 20px;
-  & path {
-    fill: ${active && theme.palette.primary.main}
-  }
-  &:hover {
-    background-color: ${theme.palette.secondary.main};
-    color: ${theme.palette.text.primary};
-    & path {
-      fill: ${theme.palette.primary.main}
-    }
-  }
-`)
 
 const SmallText = styled('span')`
   font-size: 14px;

--- a/apps/frontend/src/components/ProofPage/SankeyProof.tsx
+++ b/apps/frontend/src/components/ProofPage/SankeyProof.tsx
@@ -54,11 +54,7 @@ export const createSankeyData = (
     id: redemptionStatement.id,
     targetIds: purchases.map(p => p.certificate.id),
     type: SankeyItemType.Redemption,
-    volume: formatPower(purchases.reduce(
-      (prev, current) => prev.add(BigNumber.from(current.certificate.energyWh)),
-      BigNumber.from(0)).toString(),
-      { includeUnit: true, unit: Unit.MWh }
-    ),
+    volume: '',
   }]
 
   const certificatesNodes: ExtendedNodeProperties[] = purchases.map(purchase => ({
@@ -123,6 +119,14 @@ const sankeyColors: SankeyColors = {
   Certificate: '#61CB80',
   Proof: '#7FD9A2',
   Redemption: '#4480DB',
+}
+
+const sankeyNonTargetColors: SankeyColors = {
+  NonTargetColor: '#CFCFCF',
+  Contract: '#4e5766',
+  Certificate: '#9fbfa8',
+  Proof: '#9cb8a7',
+  Redemption: '#829cc4',
 }
 
 interface Props {
@@ -197,7 +201,7 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
                           || (link.target as any).id === proof.certificate.id
                           || (link.source as any).id === proofContract?.id
                             ? sankeyColors[(link.source as any).type as keyof(SankeyColors)]
-                            : sankeyColors.NonTargetColor
+                            : sankeyNonTargetColors[(link.source as any).type as keyof(SankeyColors)]
                         return (
                           <Link
                             key={`sankey-link-${i}`}
@@ -212,8 +216,9 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
                       graph.nodes.map(node => {
                         const nonTargetNode = node.type === SankeyItemType.Certificate && node.id !== proof.certificate.id
                          || node.type === SankeyItemType.Proof && node.id !== proof.id
+                         || node.type === SankeyItemType.Contract && node.id !== proofContract.id
                         const nodeColor = nonTargetNode
-                            ? sankeyColors.NonTargetColor
+                            ? sankeyNonTargetColors[node.type]
                             : sankeyColors[node.type]
                         return (
                           <Node

--- a/apps/frontend/src/components/ProofPage/SankeyProof.tsx
+++ b/apps/frontend/src/components/ProofPage/SankeyProof.tsx
@@ -95,10 +95,13 @@ export const createSankeyData = (
     }
     return link
   })
+
   const links = clonedLinks.map(link => ({
     source: nodes.findIndex(node => node.id === link.id),
     target: nodes.findIndex(node => node.id === link.targetIds),
-    value: parseInt(nodes.find(node => node.id === link.targetIds)?.volume ?? '0')
+    value: link.type === SankeyItemType.Redemption
+      ? parseInt(nodes.find(node => node.id === link.targetIds)?.volume ?? '0')
+      : parseInt(nodes.find(node => node.id === link.id)?.volume ?? '0')
   })).filter(item => !!item);
 
   const sankeyData = { nodes, links }
@@ -130,7 +133,7 @@ interface Props {
 export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
 
   const [isExtendedSankey, setIsExtendedSankey] = useState(false)
-  const btnText = isExtendedSankey ? 'Short View' : 'Extended View'
+  const btnText = isExtendedSankey ? 'See less' : 'See more'
   const handleBtnClick = () => setIsExtendedSankey(!isExtendedSankey)
 
   const {
@@ -165,6 +168,8 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
       : createSankeyData(contracts, redemptionStatement, purchases)
     const sankeyHeight = isExtendedSankey ? purchases.length*80 : proofContract.purchases.length*150
 
+    if (isExtendedSankey && contracts.length < 1) return (<Loader />)
+
     return (
       <PageSection>
         <Box width="100%" display="flex" justifyContent="space-between" alignItems="center">
@@ -179,7 +184,7 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
           <Sankey
               data={sankeyData}
               nodeWidth={160}
-              nodePadding={40}
+              nodePadding={30}
               width={sankeyWidth}
               height={sankeyHeight}
             >
@@ -210,7 +215,6 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
                         const nodeColor = nonTargetNode
                             ? sankeyColors.NonTargetColor
                             : sankeyColors[node.type]
-                        // const isRS = isExtendedSankey && node.type === SankeyItemType.Redemption
                         return (
                           <Node
                             key={`sankey-node-${node.id}`}
@@ -233,6 +237,13 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
       )
   }
 
+  return (
+    <Loader />
+  )
+}
+
+
+const Loader = () => {
   return (
     <Box width="100%" mt="30px" textAlign="center">
       <CircularProgress />

--- a/apps/frontend/src/components/Sankey/Link.tsx
+++ b/apps/frontend/src/components/Sankey/Link.tsx
@@ -8,6 +8,7 @@ type LinkProps = {
   link: SankeyLink<ExtendedNodeProperties, Record<string, any>>;
   color: string;
   maxWidth?: number;
+  minWidth?: number;
   width?: number;
   beneficiary?: string;
 };
@@ -38,12 +39,14 @@ function sankeyLinkHorizontalO() {
   return linkHorizontal().source(horizontalSourceO).target(horizontalTargetO);
 }
 
-export default function Link({ link, color, maxWidth, width, beneficiary }: LinkProps) {
+export default function Link({ link, color, maxWidth, minWidth, width, beneficiary }: LinkProps) {
   const linkWidth = width
     ? width
-    : maxWidth
-      ? (link.value / (link.source as any).value) * maxWidth
-      : link.width;
+    : minWidth && (link.width ?? 0) < minWidth
+      ? minWidth
+      : maxWidth
+        ? (link.value / (link.source as any).value) * maxWidth
+        : link.width;
 
   const path: any = maxWidth
     ? sankeyLinkHorizontalO()(link as any)
@@ -87,7 +90,7 @@ export default function Link({ link, color, maxWidth, width, beneficiary }: Link
          type={source.type}
          id={source.id}
          targetId={source.type === SankeyItemType.Certificate ? target.id : source.id}
-         amount={target.volume}
+         amount={source.type === SankeyItemType.Redemption ? target.volume : source.volume}
          beneficiary={beneficiary}
          period={source.period}
          generator={source.generator}

--- a/apps/frontend/src/components/Sankey/Link.tsx
+++ b/apps/frontend/src/components/Sankey/Link.tsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from "react";
 import { linkHorizontal } from "d3-shape";
 import type { SankeyLink } from "d3-sankey";
-import { ExtendedNodeProperties, SankeyItemType } from "../BeneficiaryPage/SankeyView";
 import SankeyLinkPopover from "./LinkPopover";
+import { ExtendedNodeProperties, SankeyItemType } from "./Node";
 
 type LinkProps = {
   link: SankeyLink<ExtendedNodeProperties, Record<string, any>>;

--- a/apps/frontend/src/components/Sankey/LinkPopover.tsx
+++ b/apps/frontend/src/components/Sankey/LinkPopover.tsx
@@ -97,14 +97,14 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
             {beneficiary}
           </Typography>
         </Flexbox>}
-        <Flexbox>
+        {period && <Flexbox>
           <Typography width="40%">
             Period
           </Typography>
           <Typography fontWeight="bold" width="60%">
             {period}
           </Typography>
-        </Flexbox>
+        </Flexbox>}
         <Flexbox>
           <Typography width="40%">
             Generator
@@ -115,12 +115,12 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
             </Typography>
           </Tooltip>
         </Flexbox>
-        <Flexbox>
+        {sources && <Flexbox>
           <Typography width="40%">
             Sources
           </Typography>
           <Box display={'flex'} width="60%">
-            {sources?.map(source => (
+            {sources.map(source => (
               <FuelType
                 key={`${id}-${source}`}
                 withoutText
@@ -131,7 +131,8 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
               />
             ))}
           </Box>
-        </Flexbox>
+        </Flexbox>}
+        {location &&
         <Flexbox mt="5px">
           <Typography width="40%">
             Location
@@ -139,7 +140,7 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
           <Typography fontWeight="bold" width="60%">
             {location}
           </Typography>
-        </Flexbox>
+        </Flexbox>}
         <StyledButton onClick={viewItem}>
           View {type}
         </StyledButton>

--- a/apps/frontend/src/components/Sankey/LinkPopover.tsx
+++ b/apps/frontend/src/components/Sankey/LinkPopover.tsx
@@ -9,7 +9,7 @@ import { shortifyEthAddr } from "../EthereumAddress";
 import FuelType, { FuelTypeEnum } from "../FuelType";
 import Button from "@mui/material/Button";
 import { useNavigate } from "react-router";
-import { SankeyItemType } from "../BeneficiaryPage/SankeyView";
+import { SankeyItemType } from "./Node";
 
 interface SankeyLinkPopoverProps {
   open: boolean;

--- a/apps/frontend/src/components/Sankey/Node.tsx
+++ b/apps/frontend/src/components/Sankey/Node.tsx
@@ -8,6 +8,7 @@ type NodeProps<N, L> = {
   name: string | ReactNode;
   width?: number;
   height?: number;
+  minHeight?: number;
   graph?: SankeyGraph<N, L>;
   sankey?: typeof sankey;
   volume?: string
@@ -52,6 +53,7 @@ export default function Node<N, L>({
   name,
   width,
   height,
+  minHeight,
   volume,
   textColor,
 }: NodeProps<N, L>) {
@@ -61,7 +63,7 @@ export default function Node<N, L>({
   const isLinkAnEmptyContractNode = isEmptyContractNode(link)
   const isFirstNode = !y0
   const defaultWidth = (x1 ?? 0) - (x0 ?? 0);
-  const defaultHeight = (y1 ?? 0) - (y0 ?? 0);
+  const defaultHeight = minHeight && (y1 ?? 0) - (y0 ?? 0) < minHeight ? minHeight : (y1 ?? 0) - (y0 ?? 0);
 
   const nodeWidth = (width ? width : defaultWidth);
   const nodeHeight = height ? height : defaultHeight

--- a/apps/frontend/src/components/Sankey/Node.tsx
+++ b/apps/frontend/src/components/Sankey/Node.tsx
@@ -1,7 +1,6 @@
 import { useTheme } from "@mui/material/styles";
 import type { SankeyNode, sankey, SankeyGraph } from "d3-sankey";
 import { ReactNode } from "react";
-import { ExtendedNodeProperties, SankeyItemType } from "../BeneficiaryPage/SankeyView";
 
 type NodeProps<N, L> = {
   link: SankeyNode<ExtendedNodeProperties, Record<string, any>>;
@@ -14,6 +13,25 @@ type NodeProps<N, L> = {
   volume?: string
   fullAddress?: string
   textColor?: string
+};
+
+export enum SankeyItemType {
+  Contract = 'Contract',
+  Redemption = 'Redemption',
+  Certificate = 'Certificate',
+  Proof = 'Proof'
+}
+
+export type ExtendedNodeProperties = {
+  id: string;
+  targetIds: string[];
+  type: SankeyItemType;
+  volume: string;
+  period?: string;
+  status?: string;
+  generator?: string;
+  energySources?: string[];
+  location?: string;
 };
 
 export const isContractNode = (node: SankeyNode<ExtendedNodeProperties, Record<string, any>>) => {

--- a/apps/frontend/src/components/SecondaryButton/index.tsx
+++ b/apps/frontend/src/components/SecondaryButton/index.tsx
@@ -1,0 +1,26 @@
+import Button from "@mui/material/Button"
+import { styled } from "@mui/material/styles"
+
+const SecondaryButton = styled(Button, { shouldForwardProp: (prop) => prop !== 'active' })<{ active?: boolean }>(({ theme, active }) => `
+  background-color: ${active ? theme.palette.secondary.main : theme.palette.background.paper};
+  color: ${active ? theme.palette.text.primary : theme.palette.primary.main};
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0px 4px 10px rgba(160, 154, 198, 0.2);
+  border-radius: 5px;
+  padding: 10px 12px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 20px;
+  & path {
+    fill: ${active && theme.palette.primary.main}
+  }
+  &:hover {
+    background-color: ${theme.palette.secondary.main};
+    color: ${theme.palette.text.primary};
+    & path {
+      fill: ${theme.palette.primary.main}
+    }
+  }
+`)
+
+export default SecondaryButton

--- a/apps/frontend/src/hooks/fetch/useContractsByIds.ts
+++ b/apps/frontend/src/hooks/fetch/useContractsByIds.ts
@@ -1,0 +1,28 @@
+import { contractsControllerFindOne, FindContractDto } from "@energyweb/zero-protocol-labs-api-client"
+import { uniqBy } from "lodash"
+import { useEffect, useMemo, useState } from "react"
+
+const getContract = async (id: string): Promise<FindContractDto> => {
+  return await contractsControllerFindOne(id)
+}
+
+const getAllContracts = async (
+  ids: string[],
+  setContracts: (contracts: FindContractDto[]) => void
+): Promise<void> => {
+  const contracts = await Promise.all(ids.map(async (id) => await getContract(id)))
+  const uniqContracts = uniqBy(contracts, 'id')
+  return setContracts(uniqContracts)
+}
+
+export const useContractsByIds = (contractsIds: string[]) => {
+  const [contracts, setContracts] = useState<FindContractDto[]>([])
+
+  useEffect(() => {
+    if (contractsIds.length > 0 && contracts.length === 0) {
+      getAllContracts(contractsIds, setContracts)
+    }
+  }, [contractsIds])
+
+  return useMemo(() => ({ contracts }), [contractsIds])
+}

--- a/apps/frontend/src/hooks/fetch/useContractsByIds.ts
+++ b/apps/frontend/src/hooks/fetch/useContractsByIds.ts
@@ -24,5 +24,5 @@ export const useContractsByIds = (contractsIds: string[]) => {
     }
   }, [contractsIds])
 
-  return useMemo(() => ({ contracts }), [contractsIds])
+  return useMemo(() => ({ contracts }), [contracts])
 }

--- a/apps/frontend/src/hooks/fetch/usePurchasesByIds.ts
+++ b/apps/frontend/src/hooks/fetch/usePurchasesByIds.ts
@@ -19,5 +19,5 @@ export const usePurchasesByIds = (purchaseIds: string[]) => {
     }
   }, [purchaseIds])
 
-  return useMemo(() => ({ purchases }), [purchaseIds])
+  return useMemo(() => ({ purchases }), [purchases])
 }

--- a/apps/frontend/src/hooks/fetch/usePurchasesByIds.ts
+++ b/apps/frontend/src/hooks/fetch/usePurchasesByIds.ts
@@ -1,0 +1,23 @@
+import { FullPurchaseDto, purchasesControllerFindOne } from "@energyweb/zero-protocol-labs-api-client"
+import { useEffect, useMemo, useState } from "react"
+
+const getPurchase = async (id: string): Promise<FullPurchaseDto> => {
+  return await purchasesControllerFindOne(id)
+}
+
+const getAllPurchases = async (ids: string[], setPurchases: (purchases: FullPurchaseDto[]) => void): Promise<void> => {
+  const purchases = await Promise.all(ids.map(async (id) => await getPurchase(id)))
+  return setPurchases(purchases)
+}
+
+export const usePurchasesByIds = (purchaseIds: string[]) => {
+  const [purchases, setPurchases] = useState<FullPurchaseDto[]>([])
+
+  useEffect(() => {
+    if (purchaseIds.length > 0 && purchases.length === 0) {
+      getAllPurchases(purchaseIds, setPurchases)
+    }
+  }, [purchaseIds])
+
+  return useMemo(() => ({ purchases }), [purchaseIds])
+}

--- a/apps/frontend/src/pages/ProofPage/index.tsx
+++ b/apps/frontend/src/pages/ProofPage/index.tsx
@@ -93,7 +93,7 @@ export const ProofPage = () => {
         </Box>
         <Box width={'100%'}>
           {/* <TableListProofs purchaseId={purchaseId} /> */}
-          <SankeyProof proof={data} />
+          <SankeyProof proof={data} redemptionStatementId={redemptionFile?.id} />
         </Box>
       </Grid>
     </Container>


### PR DESCRIPTION
Added Redemption Statement to the Proof Page Sankey. 
Proof Sankey is now available in 2 modes:
- short mode: only current proof+contract
- extended mode: all proofs related to current redemption statement

<img width="1440" alt="Screenshot 2022-04-15 at 09 01 27" src="https://user-images.githubusercontent.com/69903849/163535224-f10d1ced-1506-4e57-b2ed-8f8b506730d6.png">

different scale to fit into view:
<img width="758" alt="Screenshot 2022-04-15 at 09 01 44" src="https://user-images.githubusercontent.com/69903849/163535254-b68356fe-34ad-4006-9ab1-46e640e770e1.png">
