### PR TITLE
chore: edit content of redemption statement tooltip

### DIFF
--- a/apps/frontend/src/components/ProofPage/SankeyProof.tsx
+++ b/apps/frontend/src/components/ProofPage/SankeyProof.tsx
@@ -54,7 +54,11 @@ export const createSankeyData = (
     id: redemptionStatement.id,
     targetIds: purchases.map(p => p.certificate.id),
     type: SankeyItemType.Redemption,
-    volume: '',
+    volume: contracts.length > 1 ? formatPower(purchases.reduce(
+      (prev, current) => prev.add(BigNumber.from(current.certificate.energyWh)),
+      BigNumber.from(0)).toString(),
+      { includeUnit: true, unit: Unit.MWh }
+    ) : '',
   }]
 
   const certificatesNodes: ExtendedNodeProperties[] = purchases.map(purchase => ({

--- a/apps/frontend/src/components/ProofPage/SankeyProof.tsx
+++ b/apps/frontend/src/components/ProofPage/SankeyProof.tsx
@@ -197,17 +197,19 @@ export const SankeyProof = ({ proof, redemptionStatementId = '' }: Props) => {
                   <g>
                     {graph &&
                       graph.links.map((link, i) => {
-                        const linkColor = (link.source as any).id === proof.certificate.id
+                        const linkSource = link.source as any as SankeyLink<ExtendedNodeProperties, Record<string, any>>
+                        const linkColor = linkSource.id === proof.certificate.id
                           || (link.target as any).id === proof.certificate.id
-                          || (link.source as any).id === proofContract?.id
-                            ? sankeyColors[(link.source as any).type as keyof(SankeyColors)]
-                            : sankeyNonTargetColors[(link.source as any).type as keyof(SankeyColors)]
+                          || linkSource.id === proofContract?.id
+                            ? sankeyColors[linkSource.type as keyof(SankeyColors)]
+                            : sankeyNonTargetColors[linkSource.type as keyof(SankeyColors)]
                         return (
                           <Link
                             key={`sankey-link-${i}`}
                             link={link}
                             color={linkColor}
                             beneficiary={beneficiary}
+                            hidePopoverBtn={linkSource.type === SankeyItemType.Redemption}
                           />
                         )
                       })

--- a/apps/frontend/src/components/Sankey/Link.tsx
+++ b/apps/frontend/src/components/Sankey/Link.tsx
@@ -94,6 +94,9 @@ export default function Link({ link, color, maxWidth, minWidth, width, beneficia
          id={source.id}
          targetId={source.type === SankeyItemType.Certificate ? target.id : source.id}
          amount={source.type === SankeyItemType.Redemption ? target.volume : source.volume}
+         amountTitle={source.type === SankeyItemType.Redemption ? 'Certificate volume' : undefined}
+         totalAmount={source.type === SankeyItemType.Redemption ? source.volume : undefined}
+         totalAmountTitle={source.type === SankeyItemType.Redemption ? 'Redemption volume' : undefined}
          beneficiary={beneficiary}
          period={source.period}
          generator={source.generator}

--- a/apps/frontend/src/components/Sankey/Link.tsx
+++ b/apps/frontend/src/components/Sankey/Link.tsx
@@ -11,6 +11,8 @@ type LinkProps = {
   minWidth?: number;
   width?: number;
   beneficiary?: string;
+  hidePopover?: boolean;
+  hidePopoverBtn?: boolean;
 };
 
 function horizontalSourceO(d: any): [number, number] {
@@ -39,7 +41,7 @@ function sankeyLinkHorizontalO() {
   return linkHorizontal().source(horizontalSourceO).target(horizontalTargetO);
 }
 
-export default function Link({ link, color, maxWidth, minWidth, width, beneficiary }: LinkProps) {
+export default function Link({ link, color, maxWidth, minWidth, width, beneficiary, hidePopover = false, hidePopoverBtn = false }: LinkProps) {
   const linkWidth = width
     ? width
     : minWidth && (link.width ?? 0) < minWidth
@@ -82,6 +84,7 @@ export default function Link({ link, color, maxWidth, minWidth, width, beneficia
           strokeWidth: linkWidth && !isNaN(linkWidth) ? linkWidth : 0,
         }}
       />
+      {!hidePopover &&
       <SankeyLinkPopover
          open={popoverOpen}
          anchorEl={popoverAnchor.current}
@@ -96,7 +99,8 @@ export default function Link({ link, color, maxWidth, minWidth, width, beneficia
          generator={source.generator}
          sources={source.energySources}
          location={source.location}
-      />
+         hideBtn={hidePopoverBtn}
+      />}
     </>
   );
 }

--- a/apps/frontend/src/components/Sankey/LinkPopover.tsx
+++ b/apps/frontend/src/components/Sankey/LinkPopover.tsx
@@ -26,6 +26,7 @@ interface SankeyLinkPopoverProps {
   location?: string[];
   link?: string;
   targetId: string;
+  hideBtn?: boolean;
 }
 
 const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
@@ -41,7 +42,8 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
   period,
   generator,
   sources,
-  location
+  location,
+  hideBtn = false
 }) => {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -105,16 +107,17 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
             {period}
           </Typography>
         </Flexbox>}
-        <Flexbox>
+       {generator &&
+       <Flexbox>
           <Typography width="40%">
             Generator
           </Typography>
-          <Tooltip title={generator ?? ''}>
+          <Tooltip title={generator}>
             <Typography fontWeight="bold" width="60%" noWrap>
-              {generator ?? '-'}
+              {generator}
             </Typography>
           </Tooltip>
-        </Flexbox>
+        </Flexbox>}
         {sources && <Flexbox>
           <Typography width="40%">
             Sources
@@ -141,9 +144,10 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
             {location}
           </Typography>
         </Flexbox>}
-        <StyledButton onClick={viewItem}>
+       {!hideBtn &&
+       <StyledButton onClick={viewItem}>
           View {type}
-        </StyledButton>
+        </StyledButton>}
       </Wrapper>
     </Popover>
   )

--- a/apps/frontend/src/components/Sankey/LinkPopover.tsx
+++ b/apps/frontend/src/components/Sankey/LinkPopover.tsx
@@ -19,6 +19,9 @@ interface SankeyLinkPopoverProps {
   type?: string;
   id?: string;
   amount?: string;
+  amountTitle?: string;
+  totalAmount?: string;
+  totalAmountTitle?: string;
   beneficiary?: string;
   period?: string;
   generator?: string;
@@ -29,10 +32,15 @@ interface SankeyLinkPopoverProps {
   hideBtn?: boolean;
 }
 
+const defaultAmountTitle = 'Amount'
+
 const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
   anchorEl,
   open,
   amount,
+  amountTitle = defaultAmountTitle,
+  totalAmount,
+  totalAmountTitle = 'Total amount',
   beneficiary,
   handleClose,
   handleOpen,
@@ -51,6 +59,8 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
     const urlType = type === SankeyItemType.Certificate ? 'purchases' : 'contracts'
     return navigate(`/partners/filecoin/${urlType}/${targetId}`)
   }
+  const labelWidth = amountTitle === defaultAmountTitle ? '40%' : '60%'
+  const valueWidth = amountTitle === defaultAmountTitle ? '60%' : '40%'
   return (
     <Popover
       id="sankey-link-popover"
@@ -75,54 +85,63 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
     >
       <Wrapper>
         <Flexbox>
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             {type}
           </Typography>
-          <Typography fontWeight="bold" width="60%">
+          <Typography fontWeight="bold" width={valueWidth}>
             {shortifyEthAddr(id ?? '')}
           </Typography>
         </Flexbox>
         <Flexbox>
-          <Typography width="40%">
-            Amount
+          <Typography width={labelWidth}>
+            {amountTitle}
           </Typography>
-          <Typography fontWeight="bold" width="60%">
+          <Typography fontWeight="bold" width={valueWidth}>
             {amount}
           </Typography>
         </Flexbox>
+       {totalAmount &&
+       <Flexbox>
+          <Typography width={labelWidth}>
+            {totalAmountTitle}
+          </Typography>
+          <Typography fontWeight="bold" width={valueWidth}>
+            {totalAmount}
+          </Typography>
+        </Flexbox>}
         {beneficiary &&
         <Flexbox>
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             Beneficiary
           </Typography>
-          <Typography fontWeight="bold" width="60%">
+          <Typography fontWeight="bold" width={valueWidth}>
             {beneficiary}
           </Typography>
         </Flexbox>}
         {period && <Flexbox>
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             Period
           </Typography>
-          <Typography fontWeight="bold" width="60%">
+          <Typography fontWeight="bold" width={valueWidth}>
             {period}
           </Typography>
         </Flexbox>}
        {generator &&
        <Flexbox>
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             Generator
           </Typography>
           <Tooltip title={generator}>
-            <Typography fontWeight="bold" width="60%" noWrap>
+            <Typography fontWeight="bold" width={valueWidth} noWrap>
               {generator}
             </Typography>
           </Tooltip>
         </Flexbox>}
         {sources && <Flexbox>
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             Sources
           </Typography>
-          <Box display={'flex'} width="60%">
+          <Box display={'flex'} width={valueWidth}>
             {sources.map(source => (
               <FuelType
                 key={`${id}-${source}`}
@@ -137,10 +156,10 @@ const SankeyLinkPopover: FC<SankeyLinkPopoverProps> = ({
         </Flexbox>}
         {location &&
         <Flexbox mt="5px">
-          <Typography width="40%">
+          <Typography width={labelWidth}>
             Location
           </Typography>
-          <Typography fontWeight="bold" width="60%">
+          <Typography fontWeight="bold" width={valueWidth}>
             {location}
           </Typography>
         </Flexbox>}


### PR DESCRIPTION
Simplified Redemption Statement link tooltip in Sankey View. Removed button and empty fields. Added "Redemption Volume" and "Certificate volume"
<img width="1385" alt="Screenshot 2022-05-05 at 09 48 06" src="https://user-images.githubusercontent.com/69903849/166882414-3351f46a-ab69-4479-92b2-de27ff5efeac.png">

