### PR TITLE
chore: Fix proof example file ID

### DIFF
--- a/apps/backend/src/files/dto/file-metadata.dto.ts
+++ b/apps/backend/src/files/dto/file-metadata.dto.ts
@@ -43,8 +43,8 @@ export class FileMetadataDto implements File {
   static toDto(dbEntity: PartialBy<File, 'content'> & { purchases: FilesOnPurchases[] }): FileMetadataDto {
     return {
       ...dbEntity,
-      purchases: dbEntity.purchases.map(p => p.purchaseId),
-      fileType: dbEntity.purchases.pop()?.fileType ?? undefined,
+      purchases: dbEntity.purchases?.map(p => p.purchaseId) ?? undefined,
+      fileType: dbEntity.purchases?.pop()?.fileType ?? undefined,
       content: dbEntity.content ?? undefined
     };
   }

--- a/apps/frontend-next/components/ProofsExamplePage/exampleData.ts
+++ b/apps/frontend-next/components/ProofsExamplePage/exampleData.ts
@@ -87,10 +87,10 @@ export const exampleData = {
             "url": "https://proofs-api.zerolabs.green/api/files/d52cf9e9-8a50-48e9-83e3-6753c14178d5"
         },
         {
-            "id": "648c16b3-6a33-48d5-a222-ba1906ec81a5",
+            "id": "b2c523d7-f352-4ce2-827a-819197bbf04c",
             "fileName": "Green-e_Attestation.pdf",
             "mimeType": "application/pdf",
-            "url": "https://proofs-api.zerolabs.green/api/files/648c16b3-6a33-48d5-a222-ba1906ec81a5"
+            "url": "https://proofs-api.zerolabs.green/api/files/b2c523d7-f352-4ce2-827a-819197bbf04c"
         }
     ],
     "pageUrl": "https://proofs.zerolabs.green/partners/filecoin/purchases/5253751e-9072-4c05-a3ae-e42428baa429"

--- a/apps/frontend/src/pages/ProofExamplePage/exampleData.ts
+++ b/apps/frontend/src/pages/ProofExamplePage/exampleData.ts
@@ -88,11 +88,11 @@ export const exampleData = {
             "url": "https://proofs-api.zerolabs.green/api/files/d52cf9e9-8a50-48e9-83e3-6753c14178d5"
         },
         {
-            "id": "648c16b3-6a33-48d5-a222-ba1906ec81a5",
+            "id": "b2c523d7-f352-4ce2-827a-819197bbf04c",
             "fileName": "Green-e_Attestation.pdf",
             "fileType": "REDEMPTION_STATEMENT",
             "mimeType": "application/pdf",
-            "url": "https://proofs-api.zerolabs.green/api/files/648c16b3-6a33-48d5-a222-ba1906ec81a5"
+            "url": "https://proofs-api.zerolabs.green/api/files/b2c523d7-f352-4ce2-827a-819197bbf04c"
         }
     ],
     "pageUrl": "https://proofs.zerolabs.green/partners/filecoin/purchases/5253751e-9072-4c05-a3ae-e42428baa429"


### PR DESCRIPTION
The proof example points to a file that no longer exists `648c16b3-6a33-48d5-a222-ba1906ec81a5`.

Fixed this by pointing to a different file.