### PR TITLE
chore(backend): Move beneficiary to purchase

### DIFF
--- a/apps/backend/prisma/migrations/20220520103214_move_beneficiary_to_purchase/migration.sql
+++ b/apps/backend/prisma/migrations/20220520103214_move_beneficiary_to_purchase/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `beneficiary` on the `Certificate` table. All the data in the column will be lost.
+  - You are about to drop the column `redemptionDate` on the `Certificate` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Certificate" DROP COLUMN "beneficiary",
+DROP COLUMN "redemptionDate";
+
+-- AlterTable
+ALTER TABLE "Purchase" ADD COLUMN     "beneficiary" TEXT,
+ADD COLUMN     "purpose" TEXT,
+ADD COLUMN     "redemptionDate" TIMESTAMP(3);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -90,8 +90,6 @@ model Certificate {
   purchase                      Purchase[]
   seller                        Seller               @relation(fields: [initialSellerId], references: [id])
   initialSellerId               String
-  beneficiary                   String?
-  redemptionDate                DateTime?
   nameplateCapacityW            Int?
   commissioningDate             DateTime?
   commissioningDateTimezoneOffset   Int?
@@ -140,6 +138,9 @@ model Purchase {
   filecoinNodeId               String?
   Contract                     Contract?                  @relation(fields: [contractId], references: [id])
   contractId                   String?
+  beneficiary                  String?
+  purpose                      String?
+  redemptionDate               DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/apps/backend/src/certificates/dto/certificate.dto.ts
+++ b/apps/backend/src/certificates/dto/certificate.dto.ts
@@ -43,13 +43,7 @@ export class CertificateDto {
   generationEndTimezoneOffset?: number;
 
   @ApiProperty({ example: '0x65ca0692df73b3ff23126fd69e15d2f7de7a317def6016ebfdeedde1e24a7a8f' })
-  txHash: string; 
-
-  @ApiPropertyOptional({ example: 'Some Corp Ltd.' })
-  beneficiary?: string;
-
-  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
-  redemptionDate?: Date;
+  txHash: string;
 
   @ApiPropertyOptional({ example: 1e9 })
   nameplateCapacityW?: number;

--- a/apps/backend/src/purchases/dto/full-purchase.dto.ts
+++ b/apps/backend/src/purchases/dto/full-purchase.dto.ts
@@ -50,6 +50,15 @@ export class FullPurchaseDto {
   @ApiPropertyOptional({ example: 180 })
   reportingEndTimezoneOffset;
 
+  @ApiProperty({ example: 'Decarbonizing Filecoin Mining Operation' })
+  purpose: string;
+
+  @ApiProperty({ example: 'Some Corp Ltd.' })
+  beneficiary: string;
+
+  @ApiProperty({ example: '2021-06-30T23:59:59.999Z' })
+  redemptionDate: Date;
+
   @ApiProperty({ type: FilecoinNodeDto })
   filecoinNode: FilecoinNodeDto;
 

--- a/apps/backend/src/purchases/dto/purchase.dto.ts
+++ b/apps/backend/src/purchases/dto/purchase.dto.ts
@@ -35,6 +35,15 @@ export class PurchaseDto {
   @ApiProperty({ type: String, example: 'f1234' })
   filecoinNodeId: string;
 
+  @ApiPropertyOptional({ example: 'Decarbonizing Filecoin Mining Operation' })
+  purpose?: string;
+
+  @ApiPropertyOptional({ example: 'Some Corp Ltd.' })
+  beneficiary?: string;
+
+  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
+  redemptionDate?: Date;
+
   @ApiProperty( { example: "2021-08-26T18:20:30.633Z" })
   createdAt: Date;
 
@@ -58,6 +67,9 @@ export class PurchaseDto {
       reportingEndTimezoneOffset: p.reportingEndTimezoneOffset,
       contractId: p.contractId,
       filecoinNodeId: p.filecoinNodeId,
+      beneficiary: p.beneficiary,
+      purpose: p.purpose,
+      redemptionDate: p.redemptionDate,
       createdAt: p.createdAt,
       updatedAt: p.updatedAt
     };

--- a/apps/frontend-next/components/ProofsExamplePage/exampleData.ts
+++ b/apps/frontend-next/components/ProofsExamplePage/exampleData.ts
@@ -51,13 +51,11 @@ export const exampleData = {
             }
         ]
     },
-    "filecoinNodes": [
-        {
-            "id": "f0763337",
-            "buyerId": "53fb6148-eb21-42de-91d6-f6195d028520",
-            "blockchainAddress": null
-        }
-    ],
+    "filecoinNode": {
+        "id": "f0763337",
+        "buyerId": "53fb6148-eb21-42de-91d6-f6195d028520",
+        "blockchainAddress": null
+    },
     "certificate": {
         "id": "55a057a4-8955-4d5b-96df-3ac0d56aa197",
         "energy": "108000000",

--- a/apps/frontend-next/pages/proofs/[id].tsx
+++ b/apps/frontend-next/pages/proofs/[id].tsx
@@ -74,7 +74,7 @@ const ProofPage: NextPage = () => {
                   fromDate: data.certificate.generationStart,
                   toDate: data.certificate.generationEnd,
                 }}
-                filecoinMinerIdList={data.filecoinNodes}
+                filecoinMinerIdList={data.filecoinNode}
                 buyer={data.buyer}
                 seller={data.seller}
               />

--- a/apps/frontend-next/pages/proofs/example.tsx
+++ b/apps/frontend-next/pages/proofs/example.tsx
@@ -45,7 +45,7 @@ const ProofExamplePage: NextPage = () => {
                   fromDate: exampleData.certificate.generationStart,
                   toDate: exampleData.certificate.generationEnd,
                 }}
-                filecoinMinerIdList={exampleData.filecoinNodes}
+                filecoinMinerIdList={exampleData.filecoinNode}
                 buyer={exampleData.buyer}
                 seller={exampleData.seller}
               />

--- a/apps/frontend/src/pages/ProofExamplePage/exampleData.ts
+++ b/apps/frontend/src/pages/ProofExamplePage/exampleData.ts
@@ -11,6 +11,8 @@ export const exampleData = {
     "reportingStartTimezoneOffset": -360,
     "reportingEnd": "2021-12-31T23:59:59.999Z",
     "reportingEndTimezoneOffset": -360,
+    "beneficiary": "Buyer 2",
+    "redemptionDate": "2022-01-24T15:16:08.564Z",
     "seller": {
         "id": "8c0a45ce-1594-4107-baf0-ce8846b34afd",
         "name": "3Degrees Group, Inc",
@@ -51,13 +53,11 @@ export const exampleData = {
             }
         ]
     },
-    "filecoinNodes": [
-        {
-            "id": "f0763337",
-            "buyerId": "53fb6148-eb21-42de-91d6-f6195d028520",
-            "blockchainAddress": null
-        }
-    ],
+    "filecoinNode": {
+        "id": "f0763337",
+        "buyerId": "53fb6148-eb21-42de-91d6-f6195d028520",
+        "blockchainAddress": null
+    },
     "certificate": {
         "id": "w55a057a4-8955-4d5b-96df-3ac0d56aa197",
         "energyWh": "108000000",
@@ -73,8 +73,6 @@ export const exampleData = {
         "generationEndTimezoneOffset": -360,
         "txHash": null,
         "initialSellerId": "8c0a45ce-1594-4107-baf0-ce8846b34afd",
-        "beneficiary": "Buyer 2",
-        "redemptionDate": "2022-01-24T15:16:08.564Z",
         "capacity": 1850000,
         "commissioningDate": "2014-09-01T00:00:00.000Z",
         "label": null

--- a/apps/frontend/src/pages/ProofExamplePage/index.tsx
+++ b/apps/frontend/src/pages/ProofExamplePage/index.tsx
@@ -107,6 +107,7 @@ const certificateInfoTableData: TableRowData<CertificateDto['id']>[] = [{
   id: exampleData.certificate.id ?? '',
   proofId: <EthereumAddress shortify clipboard address={exampleData.certificate.id ?? ''} />,
   product: exampleData.certificate.productType ?? '',
+  beneficiary: exampleData.beneficiary ?? '',
   amount: exampleData.certificate?.energyWh ? formatPower(exampleData.certificate.energyWh, { unit: Unit.MWh, includeUnit: true }) : '',
   period: (
   <>{dayjs(exampleData.certificate.generationStart).isValid()
@@ -124,6 +125,7 @@ const certificateInfoTableData: TableRowData<CertificateDto['id']>[] = [{
 
 const certificateInfoTableHeaders: TableHeader = {
   proofId: { label: 'Proof ID', infoText: 'Proof ID represents the identifier of proof in EW Zero marketplace' },
+  beneficiary: { label: 'Beneficiary', infoText: 'The ID of the redemption beneficiary' },
   product: { label: 'Product', infoText: 'Type of purchased EAC' },
   amount: { label: 'Amount', infoText: 'The number of EACs the buyer has bought and redeemed for their renewable energy consumption claims. 1 REC normally equals to 1 MWh of electricity produced with clean energy' },
   period: { label: 'Period', infoText: ' The “vintage”, or the dates between which the clean energy was produced. EACs require to certify consumption in a specific time frame to avoid double accounting' },

--- a/apps/frontend/src/pages/ProofExamplePage/index.tsx
+++ b/apps/frontend/src/pages/ProofExamplePage/index.tsx
@@ -107,7 +107,6 @@ const certificateInfoTableData: TableRowData<CertificateDto['id']>[] = [{
   id: exampleData.certificate.id ?? '',
   proofId: <EthereumAddress shortify clipboard address={exampleData.certificate.id ?? ''} />,
   product: exampleData.certificate.productType ?? '',
-  beneficiary: exampleData.certificate.beneficiary ?? '',
   amount: exampleData.certificate?.energyWh ? formatPower(exampleData.certificate.energyWh, { unit: Unit.MWh, includeUnit: true }) : '',
   period: (
   <>{dayjs(exampleData.certificate.generationStart).isValid()
@@ -125,7 +124,6 @@ const certificateInfoTableData: TableRowData<CertificateDto['id']>[] = [{
 
 const certificateInfoTableHeaders: TableHeader = {
   proofId: { label: 'Proof ID', infoText: 'Proof ID represents the identifier of proof in EW Zero marketplace' },
-  beneficiary: { label: 'Beneficiary', infoText: 'The ID of the redemption beneficiary' },
   product: { label: 'Product', infoText: 'Type of purchased EAC' },
   amount: { label: 'Amount', infoText: 'The number of EACs the buyer has bought and redeemed for their renewable energy consumption claims. 1 REC normally equals to 1 MWh of electricity produced with clean energy' },
   period: { label: 'Period', infoText: ' The “vintage”, or the dates between which the clean energy was produced. EACs require to certify consumption in a specific time frame to avoid double accounting' },

--- a/apps/frontend/src/pages/ProofPage/effects.tsx
+++ b/apps/frontend/src/pages/ProofPage/effects.tsx
@@ -15,7 +15,6 @@ export const certificateInfoTableHeaders: TableHeader = {
   generatorId: { label: 'Generator ID', infoText: 'ID of the device generating the energy and EACs' },
   energySource: { label: 'Energy Source', infoText: 'Renewable energy source, e.g. wind, hydro, solar, etc.' },
   region: { label: 'Region', infoText: 'Location of the device generating the energy and EACs' },
-  redemptionDate: { label: 'Redemption date', infoText: 'The date of EAC redemption' },
   seller: { label: 'Seller', infoText: 'ID of the EAC seller' }
 }
 
@@ -41,9 +40,6 @@ export const useProductPageEffects = () => {
     generatorId: data?.certificate?.generatorId ?? '',
     energySource: <FuelType fuelType={data?.certificate?.energySource as FuelTypeEnum} />,
     region: `${data?.certificate?.country}, ${data?.certificate?.region}`,
-    redemptionDate: dayjs(data?.certificate?.redemptionDate).isValid()
-      ? dayjs(data?.certificate?.redemptionDate).utc().format('YYYY-MM-DD')
-      : '-',
     seller: <EthereumAddress shortify clipboard address={data?.certificate?.initialSellerId ?? ''} />
   }]
 

--- a/apps/frontend/src/pages/ProofPage/effects.tsx
+++ b/apps/frontend/src/pages/ProofPage/effects.tsx
@@ -15,6 +15,7 @@ export const certificateInfoTableHeaders: TableHeader = {
   generatorId: { label: 'Generator ID', infoText: 'ID of the device generating the energy and EACs' },
   energySource: { label: 'Energy Source', infoText: 'Renewable energy source, e.g. wind, hydro, solar, etc.' },
   region: { label: 'Region', infoText: 'Location of the device generating the energy and EACs' },
+  redemptionDate: { label: 'Redemption date', infoText: 'The date of EAC redemption' },
   seller: { label: 'Seller', infoText: 'ID of the EAC seller' }
 }
 
@@ -40,6 +41,9 @@ export const useProductPageEffects = () => {
     generatorId: data?.certificate?.generatorId ?? '',
     energySource: <FuelType fuelType={data?.certificate?.energySource as FuelTypeEnum} />,
     region: `${data?.certificate?.country}, ${data?.certificate?.region}`,
+    redemptionDate: dayjs(data?.redemptionDate).isValid()
+      ? dayjs(data?.redemptionDate).utc().format('YYYY-MM-DD')
+      : '-',
     seller: <EthereumAddress shortify clipboard address={data?.certificate?.initialSellerId ?? ''} />
   }]
 


### PR DESCRIPTION
Task description: 

> Right now certificates expect to already have ONE fixed beneficiary when being uploaded. But this is not how the workflow with the on-chain certificates will go. ➝ Remove beneficiary if it is there
> 
> We need to allow multiple purchases per certificate. Add another field to the purchase which is amount. And then transfer & claim the on-chain certificate based on that. 
> 
> First the certificates will be extracted from the redemption statement and then we will add multiple claims with volumes and different beneficiaries to it.
> 
> In PL the purchases are basically equivalent to the claims and hold the functionality of adding multiple beneficiaries and volumes.   We should probably remove the beneficiary field from the certificates (or allow for multiple for the case when there are multiple claims). And add the stuff to the purchase entity & API that is needed for the on-chain claims (e.g. purpose). 