### PR TITLE
feat(backend): Add API pagination to all findAll() methods

### DIFF
--- a/apps/backend/src/batches/batch.controller.ts
+++ b/apps/backend/src/batches/batch.controller.ts
@@ -5,13 +5,14 @@ import {
   Get,
   Param,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
   ValidationPipe
 } from '@nestjs/common';
 import { BatchService } from './batch.service';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { BatchDto } from "./dto/batch.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
@@ -19,6 +20,7 @@ import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
 import { SetRedemptionStatementDto } from './dto/set-redemption-statement.dto';
 import { MintDto } from './dto/mint.dto';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/batch')
 @ApiTags('Filecoin Batches')
@@ -41,9 +43,14 @@ export class BatchController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [BatchDto] })
-  findAll() {
-    return this.batchService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<BatchDto>> {
+    return this.batchService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/buyers/buyers.controller.ts
+++ b/apps/backend/src/buyers/buyers.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -15,12 +16,13 @@ import {
 import { BuyersService } from './buyers.service';
 import { CreateBuyerDto } from './dto/create-buyer.dto';
 import { UpdateBuyerDto } from './dto/update-buyer.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { BuyerDto } from "./dto/buyer.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/buyers')
 @ApiTags('Filecoin buyers')
@@ -40,9 +42,14 @@ export class BuyersController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [BuyerDto] })
-  findAll(): Promise<BuyerDto[]> {
-    return this.buyersService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<BuyerDto>> {
+    return this.buyersService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/buyers/buyers.controller.ts
+++ b/apps/backend/src/buyers/buyers.controller.ts
@@ -15,7 +15,7 @@ import {
 import { BuyersService } from './buyers.service';
 import { CreateBuyerDto } from './dto/create-buyer.dto';
 import { UpdateBuyerDto } from './dto/update-buyer.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { BuyerDto } from "./dto/buyer.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
@@ -55,8 +55,16 @@ export class BuyersController {
   @Patch(':id')
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
   @ApiOkResponse({ type: BuyerDto })
+  @ApiParam({ name: 'id', type: String })
   update(@Param('id') id: string, @Body() updateBuyerDto: UpdateBuyerDto): Promise<BuyerDto> {
     return this.buyersService.update(id, updateBuyerDto);
+  }
+
+  @Patch(':id/blockchain-account')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiParam({ name: 'id', type: String })
+  attachBlockchainAccount(@Param('id') id: string): Promise<BuyerDto> {
+    return this.buyersService.assignBlockchainAccount(id);
   }
 
   @Delete(':id')

--- a/apps/backend/src/certificates/certificates.controller.ts
+++ b/apps/backend/src/certificates/certificates.controller.ts
@@ -4,11 +4,11 @@ import {
   Controller,
   Delete,
   Get,
-  NotFoundException,
   Param,
   ParseArrayPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -17,12 +17,13 @@ import {
 import { CertificatesService } from './certificates.service';
 import { CreateCertificateDto } from './dto/create-certificate.dto';
 import { UpdateCertificateDto } from './dto/update-certificate.dto';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { CertificateDto } from "./dto/certificate.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/certificates')
 @ApiTags('Filecoin certificates')
@@ -46,9 +47,14 @@ export class CertificatesController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [CertificateDto] })
-  findAll() {
-    return this.certificatesService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<CertificateDto>>  {
+    return this.certificatesService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/contracts/contracts.controller.ts
+++ b/apps/backend/src/contracts/contracts.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseArrayPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -17,11 +18,12 @@ import { ContractsService } from './contracts.service';
 import { CreateContractDto } from './dto/create-contract.dto';
 import { UpdateContractDto } from './dto/update-contract.dto';
 import { FindContractDto } from './dto/find-contract.dto';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { NoDataInterceptor } from '../interceptors/NoDataInterceptor';
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/contracts')
 @ApiTags('Filecoin contracts')
@@ -47,10 +49,14 @@ export class ContractsController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [FindContractDto] })
-  findAll(): Promise<FindContractDto[]> {
-    return this.contractsService.findAll()
-      .then((contracts) => contracts.map((contract) => FindContractDto.toDto(contract)));
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<FindContractDto>> {
+    return this.contractsService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/filecoin-nodes/filecoin-nodes.controller.ts
+++ b/apps/backend/src/filecoin-nodes/filecoin-nodes.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -15,13 +16,14 @@ import {
 import { FilecoinNodesService, transactionsSchema } from './filecoin-nodes.service';
 import { CreateFilecoinNodeDto } from './dto/create-filecoin-node.dto';
 import { UpdateFilecoinNodeDto } from './dto/update-filecoin-node.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { FilecoinNodeDto } from "./dto/filecoin-node.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { FilecoinNodeWithContractsDto } from './dto/filecoin-node-with-contracts.dto';
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/nodes')
 @ApiTags('Filecoin nodes')
@@ -40,9 +42,14 @@ export class FilecoinNodesController {
   }
 
   @Get()
-  @ApiOkResponse({ type: [FilecoinNodeDto] })
-  findAll(): Promise<FilecoinNodeDto[]> {
-    return this.filecoinNodesService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<FilecoinNodeDto>> {
+    return this.filecoinNodesService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/files/files.controller.ts
+++ b/apps/backend/src/files/files.controller.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  Query,
   Res,
   UploadedFile,
   UseGuards,
@@ -17,7 +18,7 @@ import {
   ValidationPipe
 } from '@nestjs/common';
 import { FilesService } from './files.service';
-import { ApiBody, ApiConsumes, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiConsumes, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { FileMetadataDto } from "./dto/file-metadata.dto";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { Express, Response } from 'express';
@@ -26,6 +27,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ApiKeyPermissions, FileType } from '@prisma/client';
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('files')
 @ApiTags('files')
@@ -74,10 +76,15 @@ export class FilesController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [FileMetadataDto] })
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
   @UseInterceptors(NoDataInterceptor)
-  findAll(): Promise<FileMetadataDto[]> {
-    return this.filesService.findAll();
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<FileMetadataDto>> {
+    return this.filesService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/orders/orders.controller.ts
+++ b/apps/backend/src/orders/orders.controller.ts
@@ -9,6 +9,7 @@ import {
   Patch,
   Post,
   Put,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -16,13 +17,14 @@ import {
 } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { OrderDto } from "./dto/order.dto";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ConfirmOrderDto } from './dto/confirm-order.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('orders')
 @ApiTags('Orders')
@@ -53,9 +55,14 @@ export class OrdersController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [OrderDto] })
-  findAll(): Promise<OrderDto[]> {
-    return this.ordersService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<OrderDto>> {
+    return this.ordersService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/purchases/purchases.controller.ts
+++ b/apps/backend/src/purchases/purchases.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseArrayPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -16,7 +17,7 @@ import {
 import { PurchasesService } from './purchases.service';
 import { CreatePurchaseDto } from './dto/create-purchase.dto';
 import { UpdatePurchaseDto } from './dto/update-purchase.dto';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { NoDataInterceptor } from '../interceptors/NoDataInterceptor';
 import { purchaseEventsSchema } from './purchases.service';
@@ -26,6 +27,7 @@ import { ShortPurchaseDto } from './dto/short-purchase.dto';
 import { GenerateAttestationsDto } from './dto/generate-attestations.dto';
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/purchases')
 @ApiTags('Filecoin purchases')
@@ -49,9 +51,14 @@ export class PurchasesController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [ShortPurchaseDto] })
-  findAll(): Promise<ShortPurchaseDto[]> {
-    return this.purchasesService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<ShortPurchaseDto>> {
+    return this.purchasesService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/sellers/sellers.controller.ts
+++ b/apps/backend/src/sellers/sellers.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -15,12 +16,13 @@ import {
 import { SellersService } from './sellers.service';
 import { CreateSellerDto } from './dto/create-seller.dto';
 import { UpdateSellerDto } from './dto/update-seller.dto';
-import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiSecurity, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from "@nestjs/swagger";
 import { SellerDto } from "./dto/seller.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { NoDataInterceptor } from "../interceptors/NoDataInterceptor";
 import { ApiKeyPermissionsGuard } from '../guards/apikey-permissions.guard';
 import { ApiKeyPermissions } from '@prisma/client';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Controller('/partners/filecoin/sellers')
 @ApiTags('Filecoin sellers')
@@ -41,9 +43,14 @@ export class SellersController {
 
   @Get()
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.READ]))
-  @ApiOkResponse({ type: [SellerDto] })
-  findAll(): Promise<SellerDto[]> {
-    return this.sellersService.findAll();
+  @ApiOkResponse({ type: [PaginatedDto] })
+  @ApiQuery({ name: 'skip', type: String, required: false })
+  @ApiQuery({ name: 'take', type: String, required: false })
+  findAll(
+    @Query('skip') skip?: string,
+    @Query('take') take?: string
+  ): Promise<PaginatedDto<SellerDto>> {
+    return this.sellersService.findAll({ skip: Number(skip), take: Number(take) });
   }
 
   @Get(':id')

--- a/apps/backend/src/sellers/sellers.controller.ts
+++ b/apps/backend/src/sellers/sellers.controller.ts
@@ -61,6 +61,13 @@ export class SellersController {
     return this.sellersService.update(id, updateSellerDto);
   }
 
+  @Patch(':id/blockchain-account')
+  @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.UPDATE]))
+  @ApiParam({ name: 'id', type: String })
+  attachBlockchainAccount(@Param('id') id: string): Promise<SellerDto> {
+    return this.sellersService.assignBlockchainAccount(id);
+  }
+
   @Delete(':id')
   @UseGuards(ApiKeyPermissionsGuard([ApiKeyPermissions.DELETE]))
   @ApiParam({ name: 'id', type: String })

--- a/apps/backend/src/sellers/sellers.service.ts
+++ b/apps/backend/src/sellers/sellers.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { IssuerService } from '../issuer/issuer.service';
 import { Seller } from '@prisma/client';
 import { ConfigService } from '@nestjs/config';
+import { PaginatedDto } from '../utils/paginated.dto';
 
 @Injectable()
 export class SellersService {
@@ -37,8 +38,25 @@ export class SellersService {
     return new SellerDto(await this.prisma.seller.findUnique({ where: { id: newSeller.id } }));
   }
 
-  async findAll(): Promise<SellerDto[]> {
-    return (await this.prisma.seller.findMany()).map(r => new SellerDto(r));
+  async findAll(query?: {
+    skip?: number;
+    take?: number;
+  }): Promise<PaginatedDto<SellerDto>> {
+    const total = await this.prisma.seller.count();
+
+    const take = query?.take || total;
+    const skip = query?.skip || 0;
+
+    const sellers = (await this.prisma.seller.findMany({
+      skip,
+      take
+    })).map(r => new SellerDto(r));
+
+    return {
+      data: sellers,
+      total,
+      count: sellers.length
+    };
   }
 
   async findOne(id: string): Promise<SellerDto> {

--- a/apps/backend/src/utils/paginated.dto.ts
+++ b/apps/backend/src/utils/paginated.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class PaginatedDto<T> {
+    @ApiProperty()
+    data: T[];
+
+    @ApiProperty()
+    count: number;
+
+    @ApiProperty()
+    total: number;
+}

--- a/apps/tokenization/src/app/app.module.ts
+++ b/apps/tokenization/src/app/app.module.ts
@@ -20,6 +20,10 @@ import { Account } from '../account/account.entity';
 import { HttpLoggerMiddleware } from '../middlewares/http-logger.middleware';
 
 const OriginAppTypeOrmModule = () => {
+  if (!process.env.TOKENIZATION_DATABASE_URL) {
+    throw new Error('TOKENIZATION_DATABASE_URL undefined');
+  } 
+
   const entities = [
     Account,
     BlockchainProperties,
@@ -32,7 +36,7 @@ const OriginAppTypeOrmModule = () => {
 
   return TypeOrmModule.forRoot({
     type: 'postgres',
-    url: process.env.DATABASE_URL,
+    url: process.env.TOKENIZATION_DATABASE_URL,
     entities,
     logging: ['info'],
     ssl: process.env.DB_SSL_OFF

--- a/workspace.json
+++ b/workspace.json
@@ -253,7 +253,7 @@
           },
           "configurations": {
             "production": {
-              "optimization": true,
+              "optimization": false,
               "extractLicenses": true,
               "inspect": false,
               "fileReplacements": [
@@ -273,7 +273,7 @@
               "cp yarn.lock ./dist/apps/tokenization/",
               "cp ./apps/tokenization/Dockerfile ./dist/apps/tokenization/",
               "mkdir -p ./dist/apps/tokenization/typeorm",
-              "cp -R ./apps/tokenization/migrations ./dist/apps/tokenization/typeorm",
+              "cp -R ./apps/tokenization/migrations ./dist/apps/tokenization/",
               "cp ./apps/tokenization/ormconfig.ts ./dist/apps/tokenization/typeorm/ormconfig.ts",
               "cp ./apps/tokenization/ormOptions.ts ./dist/apps/tokenization/typeorm/ormOptions.ts",
               "docker build --build-arg NPM_TOKEN=$(grep NPM_TOKEN .env | cut -d \"=\" -f2 | tr -d '\"') ./dist/apps/tokenization/ --pull -t zero-pl-tokenization",


### PR DESCRIPTION
## API Pagination

Adds pagination to all `findAll()` methods.

If the `findAll()` endpoint doesn't get any parameters, the API returns all the results in the format:
```json
{
    "data": [... data here],
    "total": 0, // Total number of entries in the database
    "count": 123 // Number of entries returned in the current request
}
```
This request may time out on large requests, in which case we can use pagination.

Pagination is used by providing the **optional** `skip` and `take` parameters.
- `skip` - how many entries do we want to skip before we start taking results (default: 0)
- `take` - how many entries do we want to take after the initial skipping (default: all)


### Additionally
- [Opened endpoints to manually creating blockchain addresses for sellers/buyers](https://github.com/zerolabsgreen/zero-pl/pull/82/commits/991ce10afca4d148da16b5f3b37a754f8721f67a)
- [Fixed tokenization docker container build](https://github.com/zerolabsgreen/zero-pl/pull/82/commits/5f9947f24ffee6288a5b1106a37c775e754f0bbc)