### PR TITLE
chore(backend): Undo moving redemptionDate from Certificate to Purchase

### DIFF
--- a/apps/backend/prisma/migrations/20220524115246_certificate_redemption_date_return/migration.sql
+++ b/apps/backend/prisma/migrations/20220524115246_certificate_redemption_date_return/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `redemptionDate` on the `Purchase` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Certificate" ADD COLUMN     "redemptionDate" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Purchase" DROP COLUMN "redemptionDate";

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -90,6 +90,7 @@ model Certificate {
   purchase                      Purchase[]
   seller                        Seller               @relation(fields: [initialSellerId], references: [id])
   initialSellerId               String
+  redemptionDate                DateTime?
   nameplateCapacityW            Int?
   commissioningDate             DateTime?
   commissioningDateTimezoneOffset   Int?
@@ -140,7 +141,6 @@ model Purchase {
   contractId                   String?
   beneficiary                  String?
   purpose                      String?
-  redemptionDate               DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/apps/backend/src/certificates/dto/certificate.dto.ts
+++ b/apps/backend/src/certificates/dto/certificate.dto.ts
@@ -45,6 +45,9 @@ export class CertificateDto {
   @ApiProperty({ example: '0x65ca0692df73b3ff23126fd69e15d2f7de7a317def6016ebfdeedde1e24a7a8f' })
   txHash: string;
 
+  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
+  redemptionDate?: Date;
+
   @ApiPropertyOptional({ example: 1e9 })
   nameplateCapacityW?: number;
 

--- a/apps/backend/src/certificates/dto/create-certificate.dto.ts
+++ b/apps/backend/src/certificates/dto/create-certificate.dto.ts
@@ -89,4 +89,10 @@ export class CreateCertificateDto extends OmitType(CertificateDto, ['txHash', 'c
   @IsOptional()
   @IsEnum(LabelEnumType)
   label?: LabelEnumType;
+
+  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
+  @IsOptional()
+  @IsISO8601({ strict: true })
+  @IsDatetimePrismaCompatible()
+  redemptionDate?: Date;
 }

--- a/apps/backend/src/purchases/dto/create-purchase.dto.ts
+++ b/apps/backend/src/purchases/dto/create-purchase.dto.ts
@@ -72,10 +72,4 @@ export class CreatePurchaseDto {
   @IsOptional()
   @IsUUID()
   contractId?: string;
-
-  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
-  @IsOptional()
-  @IsISO8601({ strict: true })
-  @IsDatetimePrismaCompatible()
-  redemptionDate?: Date;
 }

--- a/apps/backend/src/purchases/dto/full-purchase.dto.ts
+++ b/apps/backend/src/purchases/dto/full-purchase.dto.ts
@@ -56,9 +56,6 @@ export class FullPurchaseDto {
   @ApiProperty({ example: 'Some Corp Ltd.' })
   beneficiary: string;
 
-  @ApiProperty({ example: '2021-06-30T23:59:59.999Z' })
-  redemptionDate: Date;
-
   @ApiProperty({ type: FilecoinNodeDto })
   filecoinNode: FilecoinNodeDto;
 

--- a/apps/backend/src/purchases/dto/purchase.dto.ts
+++ b/apps/backend/src/purchases/dto/purchase.dto.ts
@@ -41,9 +41,6 @@ export class PurchaseDto {
   @ApiPropertyOptional({ example: 'Some Corp Ltd.' })
   beneficiary?: string;
 
-  @ApiPropertyOptional({ example: '2021-06-30T23:59:59.999Z' })
-  redemptionDate?: Date;
-
   @ApiProperty( { example: "2021-08-26T18:20:30.633Z" })
   createdAt: Date;
 
@@ -69,7 +66,6 @@ export class PurchaseDto {
       filecoinNodeId: p.filecoinNodeId,
       beneficiary: p.beneficiary,
       purpose: p.purpose,
-      redemptionDate: p.redemptionDate,
       createdAt: p.createdAt,
       updatedAt: p.updatedAt
     };

--- a/apps/frontend/src/pages/ProofPage/effects.tsx
+++ b/apps/frontend/src/pages/ProofPage/effects.tsx
@@ -41,8 +41,8 @@ export const useProductPageEffects = () => {
     generatorId: data?.certificate?.generatorId ?? '',
     energySource: <FuelType fuelType={data?.certificate?.energySource as FuelTypeEnum} />,
     region: `${data?.certificate?.country}, ${data?.certificate?.region}`,
-    redemptionDate: dayjs(data?.redemptionDate).isValid()
-      ? dayjs(data?.redemptionDate).utc().format('YYYY-MM-DD')
+    redemptionDate: dayjs(data?.certificate?.redemptionDate).isValid()
+      ? dayjs(data?.certificate?.redemptionDate).utc().format('YYYY-MM-DD')
       : '-',
     seller: <EthereumAddress shortify clipboard address={data?.certificate?.initialSellerId ?? ''} />
   }]

--- a/seed-dev.sh
+++ b/seed-dev.sh
@@ -93,7 +93,8 @@ curl -w "\n" -s -X 'POST' \
   "generationStart": "2021-06-02T00:00:00.000Z",
   "generationEnd": "2021-06-30T23:59:59.999Z",
   "energyWh": "7000000",
-  "nameplateCapacityW": 400000000
+  "nameplateCapacityW": 400000000,
+  "redemptionDate": "2020-01-01T00:00:00.000Z"
 }]'
 
 echo
@@ -169,6 +170,5 @@ curl -w "\n" -s -X 'POST' \
   "filecoinNodeId": "f00001",
   "contractId": "00000000-0000-0000-0000-000000666666",
   "reportingStart": "2020-01-01T00:00:00.000Z",
-  "reportingEnd": "2020-12-31T23:59:59.999Z",
-  "redemptionDate": "2020-01-01T00:00:00.000Z"
+  "reportingEnd": "2020-12-31T23:59:59.999Z"
 }]'


### PR DESCRIPTION
I made a mistake of moving the redemptionDate from Certificate to Purchase (in this [PR](https://github.com/zerolabsgreen/zero-pl/pull/79)). It should stay in the Certificate.