### PR TITLE
fix(backend): Wait until redemption statement is set on-chain

### DIFF
--- a/apps/backend/src/batches/batch.service.ts
+++ b/apps/backend/src/batches/batch.service.ts
@@ -113,12 +113,12 @@ export class BatchService {
 
     const redemptionStatement = await this.filesService.findOne(redemptionStatementFileId);
 
+    const txHash = await this.setRedemptionStatementOnChain(batch.id, redemptionStatement.id);
+
     await this.prisma.batch.update({
       data: { redemptionStatementId: redemptionStatement.id },
       where: { id: BigInt(batch.id) }
     });
-
-    const txHash = await this.setRedemptionStatementOnChain(batch.id, redemptionStatement.id);
 
     return txHash;
   }

--- a/apps/backend/src/issuer/issuer.service.ts
+++ b/apps/backend/src/issuer/issuer.service.ts
@@ -130,6 +130,8 @@ export class IssuerService {
   ): Promise<TxHash> {
     let txHash: string;
 
+    this.logger.debug(`[Batch ${batchId}] Setting redemption statement to: ${JSON.stringify(dto)}`);
+
     try {
       const responseData = (
         await this.axiosInstance.post(


### PR DESCRIPTION
Previously we updated the off-chain batch before the transaction was mined.
Now I changed the flow so that we first set the redemption statement on the on-chain batch, and then only later on the off-chain batch.