### PR TITLE
fix(backend): Use purchase amount on Zero Attestation PDF

### DIFF
--- a/apps/backend/src/purchases/purchases.service.ts
+++ b/apps/backend/src/purchases/purchases.service.ts
@@ -301,7 +301,7 @@ export class PurchasesService {
         const pdfGenerationData = {
           locals: {
             minerId: savedPurchase.filecoinNodeId,
-            orderQuantity: BigNumber.from(savedPurchase.certificate.energyWh).div(1e6).toString(),
+            orderQuantity: BigNumber.from(savedPurchase.recsSoldWh).div(1e6).toString(),
             country: savedPurchase.certificate.country.toString(),
             state: savedPurchase.certificate.region,
             generationPeriod: `${savedPurchase.certificate.generationStart.toDateString()} - ${savedPurchase.certificate.generationEnd.toDateString()}`,


### PR DESCRIPTION
We showed the energy amount of the full certificate on the Attestation PDF, but we should show the purchase amount instead.