### PR TITLE
chore: stop using node_env for ui related behaviour

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 NPM_TOKEN=
 
+# development, staging, production
+ENVIRONMENT=development
+
 SUPERADMIN_API_KEY=somethingsecret
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/zero-protocol-labs
 TOKENIZATION_DATABASE_URL=postgresql://postgres:postgres@localhost:5433/tokenization

--- a/apps/frontend/src/hooks/useAxiosDefaults.ts
+++ b/apps/frontend/src/hooks/useAxiosDefaults.ts
@@ -6,6 +6,7 @@ declare global {
       API_BASE_URL: string;
       BLOCK_EXPLORER: string;
       UI_API_KEY: string
+      ENVIRONMENT: string;
     };
   }
 }

--- a/apps/frontend/src/index.html.template
+++ b/apps/frontend/src/index.html.template
@@ -20,7 +20,8 @@
       window.config = {
         API_BASE_URL: '$API_BASE_URL',
         BLOCK_EXPLORER: '$BLOCK_EXPLORER',
-        UI_API_KEY: '$UI_API_KEY'
+        UI_API_KEY: '$UI_API_KEY',
+        ENVIRONMENT: '$ENVIRONMENT'
       };
     </script>
   </head>

--- a/apps/frontend/src/pages/WelcomePage/index.tsx
+++ b/apps/frontend/src/pages/WelcomePage/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../components/HomePage";
 
 export const WelcomePage = () => {
-  if (process.env.ENVIRONMENT === 'production') {
+  if (window.config.ENVIRONMENT === 'production') {
     window.onload = function() {
       window.location.href = "https://zerolabs.green";
     }

--- a/apps/frontend/src/pages/WelcomePage/index.tsx
+++ b/apps/frontend/src/pages/WelcomePage/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../components/HomePage";
 
 export const WelcomePage = () => {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.ENVIRONMENT === 'production') {
     window.onload = function() {
       window.location.href = "https://zerolabs.green";
     }


### PR DESCRIPTION
Remove usage of `process.env.NODE_ENV` and replaced it with a `ENVIRONMENT` variable